### PR TITLE
Fix capitalization of tranmission icon name

### DIFF
--- a/app/SupportedApps/Transmission.php
+++ b/app/SupportedApps/Transmission.php
@@ -28,7 +28,7 @@ class Transmission implements Contracts\Applications, Contracts\Livestats
     }
     public function icon()
     {
-        return 'supportedapps/Transmission.png';
+        return 'supportedapps/transmission.png';
     }
     public function configDetails()
     {


### PR DESCRIPTION
I just noticed my PR for transmission that was recently merged had a typo in the icon name.
