### PR TITLE
Add html needed to allow the site to load as a mobile app

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -23,8 +23,8 @@
         <meta name="msapplication-TileColor" content="#ffffff">
         <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
         <meta name="theme-color" content="#ffffff">
-  	    <meta name="mobile-web-app-capable" content="yes">
-  	    <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-capable" content="yes">
         <link rel="stylesheet" href="{{ mix('css/app.css') }}" type="text/css" />
 
     </head>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -23,6 +23,8 @@
         <meta name="msapplication-TileColor" content="#ffffff">
         <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
         <meta name="theme-color" content="#ffffff">
+  	<meta name="mobile-web-app-capable" content="yes">
+  	<meta name="apple-mobile-web-app-capable" content="yes">
         <link rel="stylesheet" href="{{ mix('css/app.css') }}" type="text/css" />
 
     </head>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -23,8 +23,8 @@
         <meta name="msapplication-TileColor" content="#ffffff">
         <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
         <meta name="theme-color" content="#ffffff">
-  	<meta name="mobile-web-app-capable" content="yes">
-  	<meta name="apple-mobile-web-app-capable" content="yes">
+  	    <meta name="mobile-web-app-capable" content="yes">
+  	    <meta name="apple-mobile-web-app-capable" content="yes">
         <link rel="stylesheet" href="{{ mix('css/app.css') }}" type="text/css" />
 
     </head>


### PR DESCRIPTION
This pull request simply adds a couple of meta tags to the app.blade.php file to allow mobile devices to treat the site as a mobile application. 

This is useful when you add the site to your mobile devices home screen, it will load in a fullscreen mode similar to a native application.