### PR TITLE
fix couchpotato icon capitalization

### DIFF
--- a/app/SupportedApps/CouchPotato.php
+++ b/app/SupportedApps/CouchPotato.php
@@ -23,7 +23,7 @@ class CouchPotato implements Contracts\Applications, Contracts\Livestats
     }
     public function icon()
     {
-        return 'supportedapps/couchPotato.png';
+        return 'supportedapps/couchpotato.png';
     }
     public function configDetails()
     {


### PR DESCRIPTION
I just realized the icon name should be in all lower case.
