### PR TITLE
Fixes typo in webpack.mix.js

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -11,9 +11,9 @@ let mix = require('laravel-mix');
  |
  */
 
-mix.scripts([
-    //'resources/assets/js/jquery-ui.min.js',
-    'resources/assets/js/huebee.js',
-    'resources/assets/js/app.js'
-    ], 'public/js/app.js')
+mix.js([
+      //'resources/assets/js/jquery-ui.min.js',
+      'resources/assets/js/huebee.js',
+      'resources/assets/js/app.js'
+      ], 'public/js/app.js')
    .sass('resources/assets/sass/app.scss', 'public/css').version();


### PR DESCRIPTION
Had problems running `npm run production`, but fixed it by correcting the typo.

Error[1] thrown without the fix.

[1] https://travis-ci.com/MindTooth/Heimdall/jobs/128509993#L905