### PR TITLE
Cleaned of variable population in scripts.blade.php

### DIFF
--- a/resources/views/items/scripts.blade.php
+++ b/resources/views/items/scripts.blade.php
@@ -5,16 +5,10 @@
             var elem = $('.color-picker')[0];
             var hueb = new Huebee( elem, {
               // options
-            });        
+            });
 
-            var availableTags = [
-            <?php
-                $supported = App\Item::supportedOptions();
-                foreach($supported as $sapp) {
-                    echo '"'.$sapp.'",';
-                }
-            ?>
-            ];
+            var availableTags = @json(App\Item::supportedOptions());
+
             $( "#appname" ).autocomplete({
                 source: availableTags,
                 select: function( event, ui ) {


### PR DESCRIPTION
Ed1t:  @KodeStar: Went with the light-weight solution.  This makes it easier for my #210 project.
Tested with `php artisan serve`, and the variable is populated just fine in the HTML source.  I'm able to pick from the apps  just fine.  Is it okay with you if I also move the current JavaScript to the app.js?  If so, I'll add the commit to this one before merging.

~~This removes the need to run PHP queries inside the blade file. Making
sure the blade files only render content. And also provides a
application list variable (availableApps) to be used inside blades.~~

~~If the variable is needed for more views, they need to be added to the
ComposerServiceProvider file.~~