### PR TITLE
Update Italian app.php

### DIFF
--- a/resources/lang/it/app.php
+++ b/resources/lang/it/app.php
@@ -1,20 +1,23 @@
 <?php
-
 return [
-
     /*
     |--------------------------------------------------------------------------
     | App Language Lines
     |--------------------------------------------------------------------------
     |
     */
-
     'settings.system' => 'Sistema',
     'settings.appearance' => 'Aspetto',
-    'settings.miscellaneous' => 'Miscellaneous',
-
+    'settings.miscellaneous' => 'Altre impostazioni',
+	'settings.support' => 'Supporto',
+    'settings.donate' => 'Dona',
+	
     'settings.version' => 'Versione',
     'settings.background_image' => 'Immagine di sfondo',
+	'settings.window_target' => 'Apri link in',
+	'settings.window_target.current' => 'Apri in questa scheda',
+    'settings.window_target.one' => 'Apri nella stessa scheda',
+    'settings.window_target.new' => 'Apri in una nuova scheda',
     'settings.homepage_search' => 'Ricerca in homepage',
     'settings.search_provider' => 'Motore di ricerca',
     'settings.language' => 'Lingua',
@@ -23,33 +26,35 @@ return [
     'settings.search' => 'Cerca',
     'settings.no_items' => 'Nessun elemento trovato',
     
-
-    'settings.label' => 'Etichetta',    
+    'settings.label' => 'Nome',    
     'settings.value' => 'Valore',    
     'settings.edit' => 'Modifica',    
-    'settings.view' => 'Vista',    
-
+    'settings.view' => 'Mostra',    
+ 
     'options.none' => '- non impostato -',
     'options.google' => 'Google',
     'options.ddg' => 'DuckDuckGo',
     'options.bing' => 'Bing',
     'options.qwant' => 'Qwant',
-    'options.yes' => 'Si',
+	'options.startpage' => 'StartPage',
+    'options.yes' => 'Sì',
     'options.no' => 'No',
-
+	'options.nzbhydra' => 'NZBHydra',
+	
     'buttons.save' => 'Salva',
     'buttons.cancel' => 'Annulla',
     'buttons.add' => 'Aggiungi',
-    'buttons.upload' => 'Aggiungi un file',
-
+    'buttons.upload' => 'Carica un file',
+	'buttons.downloadapps' => 'Aggiorna lista app',
+ 
     'dash.pin_item' => 'Fissa un elemento sulla dashboard',
     'dash.no_apps' => 'Non ci sono applicazioni fissate, :link1 o :link2',
     'dash.link1' => 'Aggiungi un\'applicazione qui',
     'dash.link2' => 'Fissa un elemento alla dashboard',
     'dash.pinned_items' => 'Elementi fissati',
-
-    'apps.app_list' => 'Lista delle applicazioni',
-    'apps.view_trash' => 'Guarda il cestino',
+ 
+    'apps.app_list' => 'Lista  applicazioni',
+    'apps.view_trash' => 'Mostra cestino',
     'apps.add_application' => 'Aggiungi applicazione',
     'apps.application_name' => 'Nome dell\'applicazione',
     'apps.colour' => 'Colore',
@@ -60,22 +65,49 @@ return [
     'apps.username' => 'Nome utente',
     'apps.password' => 'Password',
     'apps.config' => 'Configurazione',
-    'apps.apikey' => 'Api Key',
+    'apps.apikey' => 'Chiave API',
     'apps.enable' => 'Abilitato',
-
+	'apps.tag_list' => 'Lista tag',
+    'apps.add_tag' => 'Aggiungi tag',
+    'apps.tag_name' => 'Nome tag',
+    'apps.tags' => 'Tag',
+    'apps.override' => 'Se diverso dall\'url principale',
+    'apps.preview' => 'Anteprima',
+    'apps.apptype' => 'Tipo di applicazione',
+	
+    'dashboard' => 'Home dashboard',								   
+ 
+	'user.user_list' => 'Utenti',
+    'user.add_user' => 'Aggiungi utente',
+    'user.username' => 'Username',
+    'user.avatar' => 'Logo',
+    'user.email' => 'Email',
+    'user.password_confirm' => 'Conferma password',
+    'user.secure_front' => 'Permetti accesso pubblico alla pagina principale - Vale solo se una password è stata definita.',
+    'user.autologin' => 'Abilita login da una URL specifica. Chiunque con questa URL può accedere.',							
+	
     'url' => 'Url',
     'title' => 'Titolo',
     'delete' => 'Elimina',    
     'optional' => 'Opzionale',    
-    'restore' => 'Ripristina',    
-
+    'restore' => 'Ripristina',  
+	
     'alert.success.item_created' => 'Elemento creato con successo',
     'alert.success.item_updated' => 'Elemento aggiornato con successo',
     'alert.success.item_deleted' => 'Elemento cancellato con successo',
     'alert.success.item_restored' => 'Elemento ripristinato con successo',
-
-    'alert.success.setting_updated' => 'Hai modificato questi settaggi',
-    'alert.error.not_exist' => 'Questi settaggi non esistono.',
-
-
-];
+	'alert.success.updating' => 'Aggiornamento lista app',
+	
+	'alert.success.tag_created' => 'Tag creato con successo',
+    'alert.success.tag_updated' => 'Tag aggiornato con successo',
+    'alert.success.tag_deleted' => 'Tag eliminato con successo',
+    'alert.success.tag_restored' => 'Tag ripristinato con successo',
+	
+    'alert.success.setting_updated' => 'Hai modificato questa impostazione con successo',
+    'alert.error.not_exist' => 'Questa impostazione non esiste.',
+	
+    'alert.success.user_created' => 'Utente creato con successo',
+    'alert.success.user_updated' => 'Utente aggiornato con successo',
+    'alert.success.user_deleted' => 'Utente eliminato con successo',
+    'alert.success.user_restored' => 'Utente ripristinato con successo',
+];																		   


### PR DESCRIPTION
- Added and translated missing strings
- Reworked existing strings

**WARNING**
Looks like there is a bug: all string beginning with `alert.success` do not get translated and fallback to english. Tried with other languages, happens the same.