### PR TITLE
Improved custom search handling

### DIFF
--- a/app/Search.php
+++ b/app/Search.php
@@ -89,10 +89,14 @@ abstract class Search
             if(empty($app->class)) continue;
             if(($provider = Item::isSearchProvider($app->class)) !== false) {
                 $name = Item::nameFromClass($app->class);
-                $providers[strtolower($name)] = [
+                $providers[$app->id] = [
                     'type' => $provider->type,
                     'class' => $app->class,
                     'url' => $app->url,
+                    'title' => $app->title,
+                    'colour' => $app->colour,
+                    'icon' => $app->icon,
+                    'description' => $app->description
                 ];
 
             }
@@ -130,7 +134,11 @@ abstract class Search
                 $output .= '<select name="provider">';
                 foreach(self::providers() as $key => $searchprovider) {
                     $selected = ($key === $user_search_provider) ? ' selected="selected"' : '';
-                    $output .= '<option value="'.$key.'"'.$selected.'>'.__('app.options.'.$key).'</option>';
+                    if (is_numeric($key)) {
+                      $output .= '<option value="'.$key.'"'.$selected.'>'.$searchprovider['title'].'</option>';
+                    } else {
+                      $output .= '<option value="'.$key.'"'.$selected.'>'.__('app.options.'.$key).'</option>';
+                    }
                 }
                 $output .= '</select>';
                 $output .= Form::text('q', null, ['class' => 'homesearch', 'autofocus' => 'autofocus', 'placeholder' => __('app.settings.search').'...']);


### PR DESCRIPTION
I ran into 3 issues trying to implement `\App\SearchInterface` in an app.  This fixed 2 of them (though I'm not sure it's the ideal way).

I created an app for a searchable app I use.  There are 2x instances of the tool (in different environments).  

When I implemented the interface:
- the 2x instances of the app got folded into a single dropdown item (I could only search one)
- the dropdown in the search box showed the `app.option.appname` (a localization key that isn't defined).  I didn't want to hard-code anything into the localizations.

I tweaked the logic to refer to the external search providers by their id instead of their key and tested with `is_numeric` when populating the drop-down.  If that hits, I used the name of the app instance instead of the key of the application.  This should get around localization issues b/c the end-user decides the app instance's name.

The third issue that this doesn't fix is that the settings doesn't allow specifying an external/`\App\SearchInterface`-supplied search engine as a default.  It only shows the hardcoded ones.  It would be nice if this were possible & also if this list of hardcoded ones was customizable.