### PR TITLE
Update 'upload a file' to 'upload an icon'

### DIFF
--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -49,7 +49,7 @@ return [
     'buttons.save' => 'Save',
     'buttons.cancel' => 'Cancel',
     'buttons.add' => 'Add',
-    'buttons.upload' => 'Upload a file',
+    'buttons.upload' => 'Upload an icon',
     'buttons.downloadapps' => 'Update Apps List',
 
     'dash.pin_item' => 'Pin item to dashboard',


### PR DESCRIPTION
This updates the en language resource for 'buttons.upload' from 'upload a file' to 'upload an icon' to implement #376. Please let me know if I need to split this to it's own line but I only saw it being used in places where it appeared to referred to icons.