### PR TITLE
Fix auto-login using REMOTE_USER variable

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -85,8 +85,10 @@ class AppServiceProvider extends ServiceProvider
                 }
                 elseif(isset($_SERVER['REMOTE_USER']) && !empty($_SERVER['REMOTE_USER'])) {
                     $user = User::where('username', $_SERVER['REMOTE_USER'])->first();
-                    \Auth::login($user, true);
-                    session(['current_user' => $user]);   
+                    if ($user) {
+                        \Auth::login($user, true);
+                        session(['current_user' => $user]);
+                    }
                 }
             }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -72,7 +72,8 @@ class AppServiceProvider extends ServiceProvider
                 explode(':', base64_decode(substr($_SERVER['HTTP_AUTHORIZATION'], 6)));
             }
             if(!\Auth::check()) {
-                if(isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
+                if(isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])
+                        && !empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
                     $credentials = ['username' => $_SERVER['PHP_AUTH_USER'], 'password' => $_SERVER['PHP_AUTH_PW']];
                     
                     if (\Auth::attempt($credentials, true)) {


### PR DESCRIPTION
My reverse proxy (Traefik) provides an X-Forwarded-User header with the Keycloak username. By adding one line to `/config/nginx/site-confs/default`, the header can be set as REMOTE_USER variable:
```
        location ~ \.php$ {
                fastcgi_split_path_info ^(.+\.php)(/.+)$;
                # With php5-cgi alone:
                fastcgi_pass 127.0.0.1:9000;
                # With php5-fpm:
                #fastcgi_pass unix:/var/run/php5-fpm.sock;
                fastcgi_index index.php;
                fastcgi_param REMOTE_USER $http_x_forwarded_user; # <<< THIS LINE!
                include /etc/nginx/fastcgi_params;
        }
```

However, the auto-login didn't work because of two smalll bugs, which are solved by this pull request!

Fixes #385 

> **Note:** The auto-login feature will only be activated if you change the configuration file as mentioned above. If you do so, make sure the x-forwarded-user header cannot be set by visitors themselves! The reserve proxy should always provide/override this header to make sure it is not possible to auto-login without a password!