### PR TITLE
Make background image relative

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -95,7 +95,7 @@ class AppServiceProvider extends ServiceProvider
 
             $alt_bg = '';
             if($bg_image = Setting::fetch('background_image')) {
-                $alt_bg = ' style="background-image: url(/storage/'.$bg_image.')"';
+                $alt_bg = ' style="background-image: url(storage/'.$bg_image.')"';
             }
             $lang = Setting::fetch('language');
             \App::setLocale($lang);


### PR DESCRIPTION
**Context :**
I use Heimdall in a subfolder so that I access to it threw www.mydomain.com/heimdall/.
**Issue :**
Custom background image doesn't load because Heimdall generate an absolute link (ie : www.mydomain.com/storage/backgrounds/mycustomimage.jpeg).
**Expected behavior :**
The link expected is www.mydomain.com/heimdall/storage/backgrounds/mycustomimage.jpeg.
**Fix :**
To fix this, you have to make the path relative by replace in the code "/storage" by "storage" or "./storage".