### PR TITLE
Add custom CSS and JS settings

### DIFF
--- a/app/Setting.php
+++ b/app/Setting.php
@@ -126,6 +126,9 @@ class Setting extends Model
                 }
                 $value = Form::select('value', $options, null, ['class' => 'form-control']);
                 break;
+            case 'textarea':
+                $value = Form::textarea('value', null, ['class' => 'form-control', 'cols' => '44', 'rows' => '15']);
+                break;
             default:
                 $value = Form::text('value', null, ['class' => 'form-control']);
                 break;

--- a/database/seeds/SettingsSeeder.php
+++ b/database/seeds/SettingsSeeder.php
@@ -44,6 +44,16 @@ class SettingsSeeder extends Seeder
             $setting_group->title = 'app.settings.miscellaneous';
             $setting_group->save();
         }
+        if(!$setting_group = SettingGroup::find(4)) {
+            $setting_group = new SettingGroup;
+            $setting_group->id = 4;
+            $setting_group->title = 'app.settings.advanced';
+            $setting_group->order = 3;
+            $setting_group->save();
+        } else {
+            $setting_group->title = 'app.settings.advanced';
+            $setting_group->save();
+        }
 
         if($version = Setting::find(1)) {
             $version->label = 'app.settings.version';
@@ -192,6 +202,38 @@ class SettingsSeeder extends Seeder
             $setting->label = 'app.settings.donate';
             $setting->value = '<a rel="noopener" target="_blank" href="https://www.paypal.me/heimdall">Paypal</a>';
             $setting->system = true;
+            $setting->save();
+        }
+        
+        if(!$setting = Setting::find(10)) {
+            $setting = new Setting;
+            $setting->id = 10;
+            $setting->group_id = 4;
+            $setting->key = 'custom_css';
+            $setting->type = 'textarea';
+            $setting->label = 'app.settings.custom_css';
+            $setting->value = '';
+            $setting->save();
+        } else {
+            $setting->type = 'textarea';
+            $setting->group_id = 4;
+            $setting->label = 'app.settings.custom_css';
+            $setting->save();
+        }
+
+        if(!$setting = Setting::find(11)) {
+            $setting = new Setting;
+            $setting->id = 11;
+            $setting->group_id = 4;
+            $setting->key = 'custom_js';
+            $setting->type = 'textarea';
+            $setting->label = 'app.settings.custom_js';
+            $setting->value = '';
+            $setting->save();
+        } else {
+            $setting->type = 'textarea';
+            $setting->group_id = 4;
+            $setting->label = 'app.settings.custom_js';
             $setting->save();
         }
 

--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -12,6 +12,8 @@ return [
     'settings.system' => 'System',
     'settings.appearance' => 'Appearance',
     'settings.miscellaneous' => 'Miscellaneous',
+    'settings.advanced' => 'Advanced',
+    
     'settings.support' => 'Support',
     'settings.donate' => 'Donate',
 
@@ -29,11 +31,13 @@ return [
     'settings.search' => 'search',
     'settings.no_items' => 'No items found',
 
-
     'settings.label' => 'Label',
     'settings.value' => 'Value',
     'settings.edit' => 'Edit',
     'settings.view' => 'View',
+    
+    'settings.custom_css' => 'Custom CSS',
+    'settings.custom_js' => 'Custom JavaScript',
 
     'options.none' => '- not set -',
     'options.google' => 'Google',

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -33,6 +33,10 @@
         @else
         <base href="{{ url('') }}">
         @endif
+        <style id="custom_css">
+        /* editable using the 'Settings > Advanced > Custom CSS' option */
+        {!! \App\Setting::fetch('custom_css') !!}
+        </style>
     </head>
     <body>
         <div id="app"{!! $alt_bg !!}>
@@ -113,5 +117,9 @@
         <script src="{{ asset('js/app.js?v=4') }}"></script>
         @yield('scripts')
         
+        <script id="custom_js">
+        /* editable using the 'Settings > Advanced > Custom JavaScript' option */
+        {!! \App\Setting::fetch('custom_js') !!}
+        </script>
     </body>
 </html>

--- a/resources/views/settings/list.blade.php
+++ b/resources/views/settings/list.blade.php
@@ -25,7 +25,11 @@
                             <tr>
                                 <td>{{ __($setting->label) }}</td>
                                 <td>
+                                    @if($setting->type === "textarea")
+                                    <pre>{{ $setting->list_value }}</pre>
+                                    @else
                                     {!! $setting->list_value !!}
+                                    @endif
                                 </td>
                                 <td class="text-center">
                                     @if((bool)$setting->system !== true)


### PR DESCRIPTION
This change adds a new Advanced settings group and two new settings (both with a new `textarea` setting type):
- `custom_css`
- `custom_js`

The setting values are then written out in `resources/views/layouts/app.blade.php`.
This allows for custom tweaks to styling and colours etc.