### PR TITLE
Allow user apps to be search provider default

### DIFF
--- a/app/Search.php
+++ b/app/Search.php
@@ -12,7 +12,7 @@ abstract class Search
 
     /**
      * List of all search providers
-     * 
+     *
      * @return Array
      */
     public static function providers()
@@ -24,7 +24,7 @@ abstract class Search
 
     /**
      * Gets details for a single provider
-     * 
+     *
      * @return Object
      */
     public static function providerDetails($provider)
@@ -36,7 +36,7 @@ abstract class Search
 
     /**
      * Array of the standard providers
-     * 
+     *
      * @return Array
      */
     public static function standardProviders()
@@ -78,7 +78,7 @@ abstract class Search
     /**
      * Loops through users apps to see if app is a search provider, might be worth
      * looking into caching this at some point
-     * 
+     *
      * @return Array
      */
     public static function appProviders()
@@ -106,7 +106,7 @@ abstract class Search
 
     /**
      * Outputs the search form
-     * 
+     *
      * @return html
      */
     public static function form()
@@ -116,7 +116,7 @@ abstract class Search
         $search_provider = Setting::where('key', '=', 'search_provider')->first();
         $user_search_provider = Setting::fetch('search_provider');
         //die(print_r($search_provider));
-       
+
         //die(var_dump($user_search_provider));
         // return early if search isn't applicable
         if((bool)$homepage_search !== true) return $output;
@@ -133,7 +133,7 @@ abstract class Search
                 $output .= '<div id="search-container" class="input-container">';
                 $output .= '<select name="provider">';
                 foreach(self::providers() as $key => $searchprovider) {
-                    $selected = ($key === $user_search_provider) ? ' selected="selected"' : '';
+                    $selected = ($key == $user_search_provider) ? ' selected="selected"' : '';
                     if (is_numeric($key)) {
                       $output .= '<option value="'.$key.'"'.$selected.'>'.$searchprovider['title'].'</option>';
                     } else {

--- a/app/Setting.php
+++ b/app/Setting.php
@@ -61,22 +61,35 @@ class Setting extends Model
                     $value = '<a href="'.asset('storage/'.$this->value).'" title="'.__('app.settings.view').'" target="_blank">'.__('app.settings.view').'</a>';
                 } else {
                     $value = __('app.options.none');
-                }    
+                }
                 break;
             case 'boolean':
                 if((bool)$this->value === true) {
                     $value = __('app.options.yes');
                 } else {
                     $value = __('app.options.no');
-                }    
+                }
                 break;
             case 'select':
-                if(!empty($this->value) && $this->value !== 'none') {
-                    $options =  (array)json_decode($this->options);
-                    $value = __($options[$this->value]);
+                if ($this->key == 'search_provider') {
+                    $options = Search::providers();
+                    if (array_key_exists($this->value, $options)) {
+                        if (is_numeric($this->value)) {
+                            $value = $options[$this->value]['title'];
+                        } else {
+                            $value = __('app.options.'.$this->value);
+                        }
+                    } else {
+                        $value = __('app.options.none');
+                    }
                 } else {
-                    $value = __('app.options.none');
-                }                
+                    if(!empty($this->value) && $this->value !== 'none') {
+                        $options =  (array)json_decode($this->options);
+                        $value = __($options[$this->value]);
+                    } else {
+                        $value = __('app.options.none');
+                    }
+                }
                 break;
             default:
                 $value = __($this->value);
@@ -105,7 +118,7 @@ class Setting extends Model
                 if(isset($this->value) && !empty($this->value)) {
                     $value .= '<a class="settinglink" href="'.route('settings.clear', $this->id).'" title="'.__('app.settings.remove').'">'.__('app.settings.reset').'</a>';
                 }
-                
+
                 break;
             case 'boolean':
                 $checked = false;
@@ -120,9 +133,20 @@ class Setting extends Model
 
                 break;
             case 'select':
-                $options = json_decode($this->options);
-                foreach($options as $key => $opt) {
-                    $options->$key = __($opt);
+                if ($this->key == 'search_provider') {
+                    $options = ['none'=>'none']+Search::providers();
+                    foreach($options as $key => $searchprovider) {
+                        if (is_numeric($key)) {
+                            $options[$key] = $searchprovider['title'];
+                        } else {
+                            $options[$key] = __('app.options.'.$key);
+                        }
+                    }
+                } else {
+                    $options = json_decode($this->options);
+                    foreach($options as $key => $opt) {
+                        $options->$key = __($opt);
+                    }
                 }
                 $value = Form::select('value', $options, null, ['class' => 'form-control']);
                 break;
@@ -187,7 +211,7 @@ class Setting extends Model
                         #}
                         $value = $find->value;
                     }
-                    
+
                 }
                 #Setting::add($cachekey, $value);
 

--- a/database/seeds/SettingsSeeder.php
+++ b/database/seeds/SettingsSeeder.php
@@ -86,31 +86,19 @@ class SettingsSeeder extends Seeder
             $setting->save();
         }
 
-        $options = json_encode([
-            'none' => 'app.options.none',
-            'google' => 'app.options.google',
-            'ddg' => 'app.options.ddg',
-            'qwant' => 'app.options.qwant',
-            'bing' => 'app.options.bing',
-            'startpage' => 'app.options.startpage',
-        ]);
-
         if(!$setting = Setting::find(4)) {
-
             $setting = new Setting;
             $setting->id = 4;
             $setting->group_id = 3;
             $setting->key = 'search_provider';
             $setting->type = 'select';
-            $setting->options = $options;
             $setting->label = 'app.settings.search_provider';
             $setting->save();
         } else {
-            $setting->options = $options;
+            $setting->options = false;
             $setting->label = 'app.settings.search_provider';
             $setting->save();
         }
-
 
         $language_options = json_encode([
             'de' => 'Deutsch (German)',


### PR DESCRIPTION
This change allows a user-provided search app to be set as a default, it mainly does this by detecting the `search_provider` in `app/Settings.php`