### PR TITLE
Replace predis to php-redis

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -107,7 +107,7 @@ return [
 
     'redis' => [
 
-        'client' => 'predis',
+        'client' => 'phpredis',
 
         'default' => [
             'host' => env('REDIS_HOST', '127.0.0.1'),


### PR DESCRIPTION
Use phpredis instead predis, so heimdall can use redis caching and session correcly.
#649 