### PR TITLE
Improve Private App support

### DIFF
--- a/app/Application.php
+++ b/app/Application.php
@@ -110,6 +110,13 @@ class Application extends Model
     {
         $apps = self::apps();
         $app = $apps->where('appid', $appid)->first();
+
+        if ($app === null) {
+            // Try in db for Private App
+            $appModel = self::where('appid', $appid)->first();
+            $app = json_decode($appModel->toJson());
+        }
+
         if ($app === null) {
             return null;
         }

--- a/app/Application.php
+++ b/app/Application.php
@@ -128,6 +128,15 @@ class Application extends Model
             $list[$app->appid] = $app->name;
         }
 
+        // Check for private apps in the db
+        $appsListFromDB = self::all(['appid', 'name']);
+
+        foreach($appsListFromDB as $app) {
+            // Already existing keys are overwritten,
+            // only private apps should be added at the end
+            $list[$app->appid] = $app->name;
+        }
+
         return $list;
     }
 }

--- a/app/Console/Commands/RegisterApp.php
+++ b/app/Console/Commands/RegisterApp.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Application;
 use App\SupportedApps;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
 
 class RegisterApp extends Command
 {
@@ -65,6 +66,7 @@ class RegisterApp extends Command
                 } else {
                     // Doesn't exist so add it
                     SupportedApps::saveApp($app, new Application);
+                    $this->saveIcon($folder, $app->icon);
                     $this->info('Application Added - '.$app->name.' - '.$app->appid);
                 }
             } else {
@@ -73,5 +75,11 @@ class RegisterApp extends Command
         } else {
             $this->error('Could not find '.$json);
         }
+    }
+
+    private function saveIcon($appFolder, $icon) {
+        $iconPath = app_path('SupportedApps/' . $appFolder . '/' . $icon);
+        $contents = file_get_contents($iconPath);
+        Storage::disk('public')->put('icons/'.$icon, $contents);
     }
 }

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -17,6 +17,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
 
 class ItemController extends Controller
 {
@@ -376,7 +377,13 @@ class ItemController extends Controller
         }
 
         $output['colour'] = ($app->tile_background == 'light') ? '#fafbfc' : '#161b1f';
-        $output['iconview'] = config('app.appsource').'icons/'.$app->icon;
+        if(strpos($app->icon, 'icons/') !== false) {
+            // Private apps have the icon locally
+            $output['iconview'] = URL::to('/').'/storage/'.$app->icon;
+        } else {
+            $output['iconview'] = config('app.appsource').'icons/'.$app->icon;
+        }
+
 
         return json_encode($output);
     }

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -209,6 +209,11 @@ class ItemController extends Controller
                 $icon .= '.'.$path_parts['extension'];
             }
             $path = 'icons/'.$icon;
+
+            // Private apps could have here duplicated icons folder
+            if (strpos($path, 'icons/icons/') !== false) {
+                $path = str_replace('icons/icons/','icons/',$path);
+            }
             Storage::disk('public')->put($path, $contents);
             $request->merge([
                 'icon' => $path,
@@ -377,9 +382,13 @@ class ItemController extends Controller
         }
 
         $output['colour'] = ($app->tile_background == 'light') ? '#fafbfc' : '#161b1f';
-        if(strpos($app->icon, 'icons/') !== false) {
+
+        if(strpos($app->icon, '://') !== false) {
+            $output['iconview'] = $app->icon;
+        } elseif(strpos($app->icon, 'icons/') !== false) {
             // Private apps have the icon locally
             $output['iconview'] = URL::to('/').'/storage/'.$app->icon;
+            $output['icon'] = str_replace('icons/', '', $output['icon']);
         } else {
             $output['iconview'] = config('app.appsource').'icons/'.$app->icon;
         }


### PR DESCRIPTION
This is a try to fix 
- #862 
- https://github.com/linuxserver/Heimdall-Apps/issues/541

After a Private App was registered with `php artisan register:app Foldername` it should show up in the applications table. Now this table entry will also be listed when adding new items.

The `register:app` will now also copy the provided icon to the storage so it shows up correctly in the UI.

This PR also introduces the `--remove` option for the `register:app` job for development and testing.