### PR TITLE
fix: disable tooltips while reordering items

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -641,7 +641,7 @@ $.when($.ready).then(function () {
     }
   });
   $('#sortable').sortable('disable');
-  $('#sortable').on('mouseenter', '.item', function () {
+  $('#main').on('mouseenter', '#sortable.ui-sortable-disabled .item', function () {
     $(this).siblings('.tooltip').addClass('active');
     $('.refresh', this).addClass('active');
   }).on('mouseleave', '.item', function () {
@@ -696,8 +696,10 @@ $.when($.ready).then(function () {
       $('.add-item').hide();
       $('.item-edit').hide();
       $('#app').removeClass('sidebar');
+      $('#sortable .tooltip').css('display', '')
       $('#sortable').sortable('disable');
     } else {
+      $('#sortable .tooltip').css('display', 'none')
       $('#sortable').sortable('enable');
       setTimeout(function () {
         $('.add-item').fadeIn();

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -63,7 +63,7 @@
                             <a href="{{ route('items.index', []) }}">Items</a></li>
                     </ul>
                 </header>
-                <main>
+                <main id="main">
                     @if ($message = Session::get('success'))
                     <div class="message-container">
                         <div class="alert alert-success">


### PR DESCRIPTION
When we reorder the items, the tool-tips are still in the DOM with opacity set to 0. As the tool-tips are part of the item they are still clickable even when invisible and are overlapping items from the row above them. This leads to problems when people want to drag and drop them.

fixes #886 