### PR TITLE
fix: adjust home tag index for mysql/mariadb in database seeder

### DIFF
--- a/database/seeds/SettingsSeeder.php
+++ b/database/seeds/SettingsSeeder.php
@@ -3,6 +3,8 @@
 use App\Setting;
 use App\SettingGroup;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class SettingsSeeder extends Seeder
 {
@@ -243,7 +245,15 @@ class SettingsSeeder extends Seeder
             $home_tag->url = '';
             $home_tag->type = 1;
             $home_tag->user_id = 0;
+
             $home_tag->save();
+            $home_tag_id = $home_tag->id;
+
+            if($home_tag_id != 0) {
+                Log::info("Home Tag returned with id $home_tag_id from db! Changing to 0.");
+
+                DB::update('update items set id = 0 where id = ?', [$home_tag_id]);
+            }
 
             $homeapps = \App\Item::withoutGlobalScope('user_id')->doesntHave('parents')->get();
             foreach ($homeapps as $app) {

--- a/database/seeds/UsersSeeder.php
+++ b/database/seeds/UsersSeeder.php
@@ -15,11 +15,18 @@ class UsersSeeder extends Seeder
         // Groups
         if (! $user = User::find(1)) {
             $user = new User;
-            $user->id = 1;
             $user->username = 'admin';
             $user->email = 'admin@test.com';
             $user->password = null;
             $user->save();
+
+            $user_id = $user->id;
+
+            if($user_id != 1) {
+                Log::info("First User returned with id $user_id from db! Changing to 1.");
+
+                DB::update('update users set id = 1 where id = ?', [$user_id]);
+            }
         } else {
             //$user->save();
         }


### PR DESCRIPTION
## Issue 1:
Right now when we specify in the env file to use mysql / mariadb instead of sqlite we will receive error related to foreign key checks.

Reason for this is that when the database gets seeded the index for the home tag will be set to 1 instead of 0 in case of the above databases.

This fix should adjust the index to 0 as the home tag index of 0 is hard-coded at multiple places already. 

## Issue 2:
With PostgreSQL the first user creation will fail with the error `duplicate key value violates unique constraint "users_pkey"`

Solution is based on:
https://stackoverflow.com/questions/37970743/postgresql-unique-violation-7-error-duplicate-key-value-violates-unique-const

At seed time we retrospectively adjust the admin user id to be 1 for mysql / mardiadb, so the sequence is working fine in postgresql.

Should fix:
- https://github.com/linuxserver/Heimdall/issues/429

## Tested with
- Mariadb 10.4
- PosgreSQL 14
- sqlite