### PR TITLE
fix: Don't write existing icons to disk

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -214,7 +214,9 @@ class ItemController extends Controller
             if (strpos($path, 'icons/icons/') !== false) {
                 $path = str_replace('icons/icons/','icons/',$path);
             }
-            Storage::disk('public')->put($path, $contents);
+            if(! Storage::disk('public')->exists($path)) {
+                Storage::disk('public')->put($path, $contents);
+            }
             $request->merge([
                 'icon' => $path,
             ]);


### PR DESCRIPTION
During Private app registration the app icon is already put to the icon storage. When we want to create a new item of the type of Private app, the php runtime might not be able to overwrite the existing icon and throw a 500 error.

To avoid this the PR proposes to skip overwriting icons.

fixes: https://github.com/linuxserver/Heimdall-Apps/issues/554