### PR TITLE
Add global TLS verification skip setting

### DIFF
--- a/app/SupportedApps.php
+++ b/app/SupportedApps.php
@@ -85,6 +85,11 @@ abstract class SupportedApps
             'connect_timeout' => 15,
         ] : $overridevars;
 
+        // Check global setting to skip TLS verification (useful for self-signed certificates)
+        if (Setting::fetch('skip_tls_verification')) {
+            $vars['verify'] = false;
+        }
+
         $client = new Client($vars);
 
         $method = ($overridemethod === null || $overridemethod === false) ? $this->method : $overridemethod;

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -349,5 +349,19 @@ class SettingsSeeder extends Seeder
             $setting->label = 'app.settings.treat_tags_as';
             $setting->save();
         }
+
+        if (! $setting = Setting::find(15)) {
+            $setting = new Setting;
+            $setting->id = 15;
+            $setting->group_id = 4;
+            $setting->key = 'skip_tls_verification';
+            $setting->type = 'boolean';
+            $setting->label = 'app.settings.skip_tls_verification';
+            $setting->value = '0';
+            $setting->save();
+        } else {
+            $setting->label = 'app.settings.skip_tls_verification';
+            $setting->save();
+        }
     }
 }

--- a/lang/en/app.php
+++ b/lang/en/app.php
@@ -32,6 +32,7 @@ return array (
   'settings.folders' => 'Folders',
   'settings.tags' => 'Tags',
   'settings.categories' => 'Categories',
+  'settings.skip_tls_verification' => 'Skip TLS Verification (for self-signed certificates)',
   'options.none' => '- not set -',
   'options.google' => 'Google',
   'options.ddg' => 'DuckDuckGo',


### PR DESCRIPTION
## Summary
- Adds a new boolean setting "Skip TLS Verification" in the Advanced settings group
- When enabled, all enhanced apps will skip TLS certificate verification
- Useful for users with self-signed certificates on their services

## Changes
- `app/SupportedApps.php`: Check global setting and set `verify => false` on Guzzle client
- `database/seeders/SettingsSeeder.php`: Add new setting (ID 15, key: `skip_tls_verification`)
- `lang/en/app.php`: Add English translation for the setting label

## Test plan
- [ ] Enable the setting in Settings > Advanced
- [ ] Add an enhanced app with a self-signed certificate
- [ ] Verify API connectivity works without TLS errors
- [ ] Disable the setting and verify TLS validation is re-enabled

Resolves linuxserver/Heimdall-Apps#687