### PR TITLE
Fix checkbox config values always returning "1"

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -310,7 +310,12 @@ $.when($.ready).then(() => {
       data.url = apiurl;
       $(".config-item").each(function () {
         const config = $(this).data("config");
-        data[config] = $(this).val();
+        // For checkboxes, use checked state instead of value attribute
+        if ($(this).is(":checkbox")) {
+          data[config] = $(this).is(":checked") ? "1" : "0";
+        } else {
+          data[config] = $(this).val();
+        }
       });
 
       data.id = $("form[data-item-id]").data("item-id");


### PR DESCRIPTION
## Summary
Fixes a bug where checkbox-type config options (like `ignore_tls`) always save as `"1"` regardless of whether the checkbox is checked or unchecked.

## Problem
The JavaScript code collecting config values uses `$(this).val()` for all form elements. For checkboxes, `.val()` returns the `value` attribute (typically `"1"`) rather than reflecting the checked state. This means unchecking a boolean config option has no effect - it still saves as `"1"`.

## Solution
Check if the element is a checkbox and use the `:checked` state to determine the value:
```javascript
if ($(this).is(":checkbox")) {
  data[config] = $(this).is(":checked") ? "1" : "0";
} else {
  data[config] = $(this).val();
}
```

## Test plan
- [ ] Add an enhanced app with a boolean config option (e.g., Pi-hole with `ignore_tls`)
- [ ] Enable the checkbox, test config - verify it saves as "1"
- [ ] Disable the checkbox, test config - verify it now saves as "0"

Fixes linuxserver/Heimdall-Apps#782