### PR TITLE
Fix CVE-2025-50578: Host Header Injection & Open Redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,17 @@ APP_KEY=
 APP_DEBUG=false
 APP_URL=http://localhost
 
+# Trusted reverse proxy IP addresses (comma-separated)
+# By default, all private IP ranges are trusted (192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8, 127.0.0.1)
+# Set this to restrict to specific proxy IP(s) for improved security:
+#   TRUSTED_PROXIES=192.168.1.10
+#   TRUSTED_PROXIES=192.168.1.10,192.168.1.11
+# Set to empty string to trust no proxies:
+#   TRUSTED_PROXIES=
+# Set to * to trust all proxies (use with caution):
+#   TRUSTED_PROXIES=*
+#TRUSTED_PROXIES=
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -11,8 +11,6 @@ use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Session;
-use Illuminate\Support\Facades\URL;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -45,7 +43,6 @@ class LoginController extends Controller
      */
     public function __construct()
     {
-        Session::put('backUrl', URL::previous());
         $this->middleware('guest')->except(['logout','autologin']);
     }
 
@@ -135,7 +132,7 @@ class LoginController extends Controller
      */
     protected function authenticated(Request $request, $user): RedirectResponse
     {
-        return back();
+        return redirect()->route('dash');
     }
 
     /**
@@ -143,6 +140,6 @@ class LoginController extends Controller
      */
     public function redirectTo()
     {
-        return Session::get('url.intended') ? Session::get('url.intended') : $this->redirectTo;
+        return $this->redirectTo;
     }
 }

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -15,7 +15,7 @@ class RedirectIfAuthenticated
     public function handle(Request $request, Closure $next, string $guard = null): Response
     {
         if (Auth::guard($guard)->check()) {
-            return redirect()->intended();
+            return redirect('/');
         }
 
         return $next($request);

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -10,14 +10,43 @@ class TrustProxies extends Middleware
     /**
      * The trusted proxies for this application.
      *
-     * @var array
+     * Set TRUSTED_PROXIES in your .env file to the IP address(es) of your reverse proxy.
+     * Use '*' to trust all proxies (not recommended for production).
+     * Use comma-separated values for multiple proxies (e.g., "192.168.1.10,192.168.1.11").
+     *
+     * @var array|string|null
      */
-    protected $proxies = ['192.168.0.0/16', '172.16.0.0/12', '10.0.0.0/8', '127.0.0.1'];
+    protected $proxies;
 
     /**
      * The current proxy header mappings.
      *
-     * @var array
+     * @var int
      */
     protected $headers = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;
+
+    /**
+     * Default trusted proxies (private IP ranges for backwards compatibility).
+     */
+    private const DEFAULT_PROXIES = ['192.168.0.0/16', '172.16.0.0/12', '10.0.0.0/8', '127.0.0.1'];
+
+    /**
+     * Bootstrap the middleware.
+     */
+    public function __construct()
+    {
+        $proxies = env('TRUSTED_PROXIES');
+
+        if ($proxies === null) {
+            // Default to private IP ranges for backwards compatibility
+            $this->proxies = self::DEFAULT_PROXIES;
+        } elseif ($proxies === '*') {
+            $this->proxies = '*';
+        } elseif ($proxies === '') {
+            // Explicitly set to empty = trust no proxies
+            $this->proxies = [];
+        } else {
+            $this->proxies = array_map('trim', explode(',', $proxies));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

This PR addresses **CVE-2025-50578** as reported in #1451, which includes two security vulnerabilities:

1. **Host Header Injection** via `X-Forwarded-Host` header - allows attackers to make the application load assets (JS, CSS, images) from attacker-controlled domains
2. **Open Redirect via Referer header** - allows attackers to redirect users to malicious external domains after authentication

## Changes

### 1. Configurable Trusted Proxies (`TrustProxies.php`)

The trusted proxy configuration is now configurable via the `TRUSTED_PROXIES` environment variable.

**Backwards Compatibility:** The default behavior is unchanged - private IP ranges (`192.168.0.0/16`, `172.16.0.0/12`, `10.0.0.0/8`, `127.0.0.1`) are trusted by default, so existing setups behind reverse proxies will continue to work without changes.

**New Options:**
| Value | Behavior |
|-------|----------|
| Not set | Trusts private IP ranges (default, backwards compatible) |
| Specific IP(s) | `TRUSTED_PROXIES=192.168.1.10` or `TRUSTED_PROXIES=192.168.1.10,192.168.1.11` |
| Empty string | `TRUSTED_PROXIES=` trusts no proxies |
| Wildcard | `TRUSTED_PROXIES=*` trusts all proxies |

### 2. Open Redirect Fixes (`LoginController.php` & `RedirectIfAuthenticated.php`)

These fixes prevent attackers from redirecting users to external malicious domains via the HTTP `Referer` header:

- **Removed** `URL::previous()` usage which trusted the untrusted `Referer` header
- **Changed** `back()` redirect after authentication to use the safe `dash` route
- **Changed** `redirect()->intended()` to use a safe internal path (`/`)
- **Removed** session-based redirect URL that could contain external domains

These changes are applied unconditionally and improve security for all users.

## How to Secure Your Instance

### For users who want enhanced security:

Add to your `.env` file:

```env
# Restrict to your specific reverse proxy IP
TRUSTED_PROXIES=192.168.1.10

# Or for multiple proxies
TRUSTED_PROXIES=192.168.1.10,192.168.1.11

# Or to trust no proxies (if not behind a reverse proxy)
TRUSTED_PROXIES=
```

### For users behind dynamic proxies (e.g., Docker networks):

The default behavior (trusting private IPs) or `TRUSTED_PROXIES=*` should work, but be aware this is less restrictive.

## Testing

- [x] Existing reverse proxy setups continue to work without configuration changes
- [x] `TRUSTED_PROXIES` can be set to restrict trusted proxies
- [x] Authentication redirects to dashboard instead of potentially malicious external URLs
- [x] No breaking changes for existing users

## References

- Issue: #1451
- CVE: CVE-2025-50578
- [Full Technical Report](https://medium.com/@juanfelipeoz.rar/cve-2025-50578-exploiting-host-header-injection-open-redirect-in-heimdall-application-733afceff2ea)