### PR TITLE
fix: proxy options in ItemController

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -271,7 +271,7 @@ class ItemController extends Controller
             $httpsProxy = getenv('HTTPS_PROXY');
             $httpsProxyLower = getenv('https_proxy');
             if ($httpsProxy !== false || $httpsProxyLower !== false) {
-                $options['proxy']['http'] = $httpsProxy ?: $httpsProxyLower;
+                $options['http']['proxy'] = $httpsProxy ?: $httpsProxyLower;
             }
 
             $file = $request->input('icon');


### PR DESCRIPTION
The correct context is http->proxy :

https://www.php.net/manual/en/context.http.php