### PR TITLE
Fix CI: pin Node 24 and install frontend deps with npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,17 @@ jobs:
           cp .env.example .env
           php artisan key:generate
 
-      - name: Cache yarn dependencies
-        uses: actions/cache@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          path: node_modules
-          key: yarn-${{ hashFiles('yarn.lock') }}
+          node-version: '24'
+          cache: 'npm'
 
-      - name: Run yarn
-        run: yarn && yarn dev
+      - name: Install node modules and build assets
+        run: npm ci && npm run dev
 
       - name: Run ESLint
-        run: yarn lint
+        run: npm run lint
 
       - name: Run tests
         run: php artisan test

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
     "packages": {
         "": {
             "dependencies": {
-                "select2": "^4.0.13",
+                "select2": "~4.0.13",
                 "sortablejs": "^1.15.0"
             },
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "webpack-cli": "^6.0.1"
     },
     "dependencies": {
-        "select2": "^4.0.13",
+        "select2": "~4.0.13",
         "sortablejs": "^1.15.0"
     }
 }


### PR DESCRIPTION
## Problem

CI (`ci.yml`) has been red since ~Nov 2025 on every PR. It ran `yarn && yarn dev` with **no committed `yarn.lock`**, so each run resolved the latest matching versions and dependency drift broke the pipeline two ways:

1. **`select2` 4.1.0** added `engines.node ">=24"`, but the runner used Node 22 → `yarn install` failed outright.
2. **`webpack` 5.108** removed `lib/SizeFormatHelpers`, which `laravel-mix@6` still `require()`s → `yarn dev` would fail the build regardless of Node version.

This is pre-existing infra drift, unrelated to any feature PR — it fails identically on all of them.

## Change

- Install with **`npm ci`**, which uses the exact versions already pinned in the committed `package-lock.json` (select2 4.0.13, webpack 5.100.1) instead of floating to latest.
- Pin the runner to **Node 24** via `actions/setup-node@v4` (with npm caching) so the toolchain is explicit.
- Pin `select2` to `~4.0.13` in `package.json` so a future `npm install` can't reintroduce the Node-24-only 4.1.0.

`webpack` stays at 5.100.1 because `laravel-mix@6` (unmaintained) requires the removed `SizeFormatHelpers`; a longer-term fix is migrating the asset pipeline off laravel-mix.

## Verification

Locally with the locked versions: `npm ci` → `npm run dev` compiles successfully and `npm run lint` passes clean, on Node 24. Once merged, the other open PRs go green on re-run.