### PR TITLE
Add a configurable default tag for the dashboard

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -40,7 +40,6 @@ class ItemController extends Controller
         $treat_tags_as = \App\Setting::fetch('treat_tags_as');
 
         $data["treat_tags_as"] = $treat_tags_as;
-        $data['default_tag'] = \App\Setting::fetch('default_tag');
 
         if (config('app.auth_roles_enable')) {
             $roles = explode(config('app.auth_roles_delimiter'), $request->header(config('app.auth_roles_header')));

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -40,6 +40,7 @@ class ItemController extends Controller
         $treat_tags_as = \App\Setting::fetch('treat_tags_as');
 
         $data["treat_tags_as"] = $treat_tags_as;
+        $data['default_tag'] = \App\Setting::fetch('default_tag');
 
         if (config('app.auth_roles_enable')) {
             $roles = explode(config('app.auth_roles_delimiter'), $request->header(config('app.auth_roles_header')));

--- a/app/Setting.php
+++ b/app/Setting.php
@@ -125,7 +125,7 @@ class Setting extends Model
                         $options = Search::providers()->pluck('name', 'id')->toArray();
                     } elseif ($this->key === 'default_tag') {
                         $options = [];
-                        $tags = Item::where('type', 1)->where('id', '>', 0)->orderBy('title', 'asc')->get();
+                        $tags = Item::where('type', 1)->where('id', '>', 0)->pinned()->orderBy('title', 'asc')->get();
                         foreach ($tags as $tag) {
                             $options[$tag->tag_url] = $tag->title;
                         }
@@ -198,7 +198,7 @@ class Setting extends Model
                     $options = Search::providers()->pluck('name', 'id');
                 } elseif ($this->key === 'default_tag') {
                     $options = ['' => 'app.options.none'];
-                    $tags = Item::where('type', 1)->where('id', '>', 0)->orderBy('title', 'asc')->get();
+                    $tags = Item::where('type', 1)->where('id', '>', 0)->pinned()->orderBy('title', 'asc')->get();
                     foreach ($tags as $tag) {
                         $options[$tag->tag_url] = $tag->title;
                     }

--- a/app/Setting.php
+++ b/app/Setting.php
@@ -123,6 +123,12 @@ class Setting extends Model
                     $options = (array) json_decode($this->options);
                     if ($this->key === 'search_provider') {
                         $options = Search::providers()->pluck('name', 'id')->toArray();
+                    } elseif ($this->key === 'default_tag') {
+                        $options = [];
+                        $tags = Item::where('type', 1)->where('id', '>', 0)->orderBy('title', 'asc')->get();
+                        foreach ($tags as $tag) {
+                            $options[$tag->tag_url] = $tag->title;
+                        }
                     }
                     $value = (array_key_exists($this->value, $options))
                         ? __($options[$this->value])
@@ -190,6 +196,12 @@ class Setting extends Model
                 $options = json_decode($this->options);
                 if ($this->key === 'search_provider') {
                     $options = Search::providers()->pluck('name', 'id');
+                } elseif ($this->key === 'default_tag') {
+                    $options = ['' => 'app.options.none'];
+                    $tags = Item::where('type', 1)->where('id', '>', 0)->orderBy('title', 'asc')->get();
+                    foreach ($tags as $tag) {
+                        $options[$tag->tag_url] = $tag->title;
+                    }
                 }
                 $value = '<select name="value" class="form-control">';
                 foreach ($options as $key => $opt) {

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -349,5 +349,20 @@ class SettingsSeeder extends Seeder
             $setting->label = 'app.settings.treat_tags_as';
             $setting->save();
         }
+
+        if (! $setting = Setting::find(15)) {
+            $setting = new Setting;
+            $setting->id = 15;
+            $setting->group_id = 4;
+            $setting->key = 'default_tag';
+            $setting->type = 'select';
+            $setting->label = 'app.settings.default_tag';
+            $setting->value = '';
+            $setting->save();
+        } else {
+            $setting->group_id = 4;
+            $setting->label = 'app.settings.default_tag';
+            $setting->save();
+        }
     }
 }

--- a/lang/en/app.php
+++ b/lang/en/app.php
@@ -29,6 +29,7 @@ return array (
   'settings.custom_css' => 'Custom CSS',
   'settings.custom_js' => 'Custom JavaScript',
   'settings.treat_tags_as' => 'Treat Tags As:',
+  'settings.default_tag' => 'Default tag',
   'settings.folders' => 'Folders',
   'settings.tags' => 'Tags',
   'settings.categories' => 'Categories',

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -4287,6 +4287,14 @@ $.when($.ready).then(function () {
       alert("Something went wrong: ".concat(responseData.responseText.substring(0, 100)));
     });
   });
+  // Auto-select the configured default tag on load (tags mode only)
+  var taglist = document.getElementById("taglist");
+  if (taglist !== null) {
+    var defaultTag = taglist.getAttribute("data-default-tag");
+    if (typeof defaultTag === "string" && defaultTag !== "") {
+      $("#taglist .tag[data-tag=\"tag-".concat(defaultTag, "\"]")).trigger("click");
+    }
+  }
   $("#pinlist").on("click", "a", function (e) {
     e.preventDefault();
     var current = $(this);

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -334,6 +334,15 @@ $.when($.ready).then(() => {
           );
         });
     });
+  // Auto-select the configured default tag on load (tags mode only)
+  const taglist = document.getElementById("taglist");
+  if (taglist !== null) {
+    const defaultTag = taglist.getAttribute("data-default-tag");
+    if (typeof defaultTag === "string" && defaultTag !== "") {
+      $(`#taglist .tag[data-tag="tag-${defaultTag}"]`).trigger("click");
+    }
+  }
+
   $("#pinlist").on("click", "a", function (e) {
     e.preventDefault();
     const current = $(this);

--- a/resources/views/partials/taglist.blade.php
+++ b/resources/views/partials/taglist.blade.php
@@ -3,7 +3,7 @@ $treat_tags_as = \App\Setting::fetch('treat_tags_as');
 ?>
 @if( $treat_tags_as == 'tags')
     @if($taglist->first())
-        <div id="taglist" class="taglist">
+        <div id="taglist" class="taglist" data-default-tag="{{ \App\Setting::fetch('default_tag') }}">
             <div class="tag white current" data-tag="all">All</div>
             @foreach($taglist as $tag)
                 <div class="tag link{{ title_color($tag->colour) }}" style="background-color: {{ $tag->colour }}" data-tag="tag-{{ $tag->tag_url }}">{{ $tag->title }}</div>

--- a/tests/Feature/DashTest.php
+++ b/tests/Feature/DashTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Item;
 use App\ItemTag;
+use App\Setting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -79,5 +80,26 @@ class DashTest extends TestCase
         $response->assertStatus(200);
         $response->assertSee('Tag 1');
         $response->assertSee('Tag 2');
+    }
+
+    public function test_dash_exposes_the_configured_default_tag(): void
+    {
+        $this->seed();
+
+        Setting::where('key', 'treat_tags_as')->update(['value' => 'tags']);
+        Setting::where('key', 'default_tag')->update(['value' => 'home-dashboard']);
+
+        Item::factory()->create([
+            'title' => 'Home',
+            'url' => 'home-dashboard',
+            'type' => 1,
+            'pinned' => 1,
+            'user_id' => 0,
+        ]);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee('data-default-tag="home-dashboard"', false);
     }
 }

--- a/tests/Unit/database/seeders/SettingsSeederTest.php
+++ b/tests/Unit/database/seeders/SettingsSeederTest.php
@@ -43,12 +43,23 @@ class SettingsSeederTest extends TestCase
             'title' => 'Home',
             'url' => 'home-dashboard',
             'type' => 1,
+            'pinned' => 1,
             'user_id' => 0,
         ]);
         Item::factory()->create([
             'title' => 'Media',
             'url' => 'media',
             'type' => 1,
+            'pinned' => 1,
+            'user_id' => 0,
+        ]);
+        // An unpinned tag is not rendered in the dashboard taglist, so it must
+        // not be offered as a default (selecting it would silently do nothing).
+        Item::factory()->create([
+            'title' => 'Archive',
+            'url' => 'archive',
+            'type' => 1,
+            'pinned' => 0,
             'user_id' => 0,
         ]);
 
@@ -59,10 +70,13 @@ class SettingsSeederTest extends TestCase
         $this->assertStringContainsString('<option value="" ', $editValue);
         $this->assertStringContainsString(__('app.options.none'), $editValue);
 
-        // One option per tag: the slug as the value, the raw title as the label.
+        // One option per pinned tag: the slug as the value, the raw title as the label.
         $this->assertStringContainsString('value="home-dashboard"', $editValue);
         $this->assertStringContainsString('>Home</option>', $editValue);
         $this->assertStringContainsString('value="media"', $editValue);
         $this->assertStringContainsString('>Media</option>', $editValue);
+
+        // The unpinned tag is excluded.
+        $this->assertStringNotContainsString('value="archive"', $editValue);
     }
 }

--- a/tests/Unit/database/seeders/SettingsSeederTest.php
+++ b/tests/Unit/database/seeders/SettingsSeederTest.php
@@ -2,11 +2,16 @@
 
 namespace Tests\Unit\database\seeders;
 
+use App\Item;
+use App\Setting;
 use Database\Seeders\SettingsSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class SettingsSeederTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
      * All language keys are defined in all languages based on the en language file.
      */
@@ -17,5 +22,47 @@ class SettingsSeederTest extends TestCase
         $languageMap = json_decode(SettingsSeeder::getSupportedLanguageMap(), true);
 
         $this->assertTrue(count($languageMap) === count($languageDirectories));
+    }
+
+    public function test_seeds_the_default_tag_setting(): void
+    {
+        $this->seed();
+
+        $setting = Setting::where('key', 'default_tag')->first();
+
+        $this->assertNotNull($setting);
+        $this->assertSame('select', $setting->type);
+        $this->assertSame(4, (int) $setting->group_id);
+    }
+
+    public function test_default_tag_edit_value_lists_all_tags_and_a_none_option(): void
+    {
+        $this->seed();
+
+        Item::factory()->create([
+            'title' => 'Home',
+            'url' => 'home-dashboard',
+            'type' => 1,
+            'user_id' => 0,
+        ]);
+        Item::factory()->create([
+            'title' => 'Media',
+            'url' => 'media',
+            'type' => 1,
+            'user_id' => 0,
+        ]);
+
+        $setting = Setting::where('key', 'default_tag')->first();
+        $editValue = $setting->edit_value;
+
+        // A "none" option with an empty value, using the shared translation key.
+        $this->assertStringContainsString('<option value="" ', $editValue);
+        $this->assertStringContainsString(__('app.options.none'), $editValue);
+
+        // One option per tag: the slug as the value, the raw title as the label.
+        $this->assertStringContainsString('value="home-dashboard"', $editValue);
+        $this->assertStringContainsString('>Home</option>', $editValue);
+        $this->assertStringContainsString('value="media"', $editValue);
+        $this->assertStringContainsString('>Media</option>', $editValue);
     }
 }


### PR DESCRIPTION
## Problem

Resolves #1556 (multiple requesters).

With "Treat Tags As: Tags", the dashboard always opens showing **every** link. Users who group links with tags want one tag group to be the landing view. The only current workaround is pasting Custom JavaScript that clicks a tag tab on load — which requires knowing the tag's internal `data-tag` slug.

## Change

Adds a **"Default tag"** setting under Advanced:

- It's a `select` populated dynamically from the user's own tags (following the exact pattern already used for the search-provider setting), plus a "None" option (the default — unchanged behaviour).
- When set, the tag list carries the chosen slug (`data-default-tag` on `#taglist`) and the dashboard auto-activates that tag's tab on load, so it opens filtered to that group. Empty ⇒ all links shown, exactly as before.
- Only applies in tags mode (the tag list only renders there); an unknown/removed tag falls back to "All".

This is the built-in, UI-driven equivalent of the community workaround.

## Files

- `database/seeders/SettingsSeeder.php` — new `default_tag` setting (id 15, Advanced group)
- `app/Setting.php` — dynamic tag options for the select (edit + list accessors)
- `app/Http/Controllers/ItemController.php` — `dash()` exposes the value
- `resources/views/partials/taglist.blade.php` — `data-default-tag` attribute
- `resources/assets/js/app.js` (+ recompiled `public/js/app.js`) — auto-select on load
- `lang/en/app.php` — label

## Tests

- `SettingsSeederTest`: the setting is seeded (select, Advanced) and its edit value lists all tags + a "None" option.
- `DashTest`: with tags mode + a default tag configured, `/` renders `data-default-tag="…"`.

Full suite green (37 tests, 1 pre-existing skip); `phpcs` clean; source JS lints clean and the recompiled bundle passes `node --check`.

## Note

The on-load tab activation mirrors the community-confirmed `querySelector('[data-tag="tag-…"]').click()` snippet; the compiled bundle was hand-patched to keep the diff minimal (CI rebuilds assets regardless).