### PR TITLE
Bump version to 2.7.8

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Facade;
 
 return [
 
-    'version' => '2.7.7',
+    'version' => '2.7.8',
 
     'appsource' => env('APP_SOURCE', 'https://appslist.heimdall.site/'),
 


### PR DESCRIPTION
Bumps `config/app.php` `version` from 2.7.7 to 2.7.8 for the next release, which collects the fixes in this batch:

- #1567 — include tags in item export / restore on import (#1555)
- #1568 — host header injection & open redirect hardening (#1451, CVE-2025-50578)
- #1569 — security dependency updates + PHP 8.4 baseline (#1564)
- #1570 — graceful `get_stats` output instead of 500 (#1558)
- #1571 — CI fix (Node 24 + `npm ci`) — already merged
- #1572 — configurable default dashboard tag (#1556)

The in-app version display reads `config('app.version')`, so no other change is required.