### PR TITLE
Add global TLS verification skip setting

### DIFF
--- a/app/SupportedApps.php
+++ b/app/SupportedApps.php
@@ -85,6 +85,11 @@ abstract class SupportedApps
             'connect_timeout' => 15,
         ] : $overridevars;
 
+        // Check global setting to skip TLS verification (useful for self-signed certificates)
+        if (Setting::fetch('skip_tls_verification')) {
+            $vars['verify'] = false;
+        }
+
         $client = new Client($vars);
 
         $method = ($overridemethod === null || $overridemethod === false) ? $this->method : $overridemethod;

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -364,5 +364,19 @@ class SettingsSeeder extends Seeder
             $setting->label = 'app.settings.default_tag';
             $setting->save();
         }
+
+        if (! $setting = Setting::find(16)) {
+            $setting = new Setting;
+            $setting->id = 16;
+            $setting->group_id = 4;
+            $setting->key = 'skip_tls_verification';
+            $setting->type = 'boolean';
+            $setting->label = 'app.settings.skip_tls_verification';
+            $setting->value = '0';
+            $setting->save();
+        } else {
+            $setting->label = 'app.settings.skip_tls_verification';
+            $setting->save();
+        }
     }
 }

--- a/lang/en/app.php
+++ b/lang/en/app.php
@@ -33,6 +33,7 @@ return array (
   'settings.folders' => 'Folders',
   'settings.tags' => 'Tags',
   'settings.categories' => 'Categories',
+  'settings.skip_tls_verification' => 'Skip TLS Verification (for self-signed certificates)',
   'options.none' => '- not set -',
   'options.google' => 'Google',
   'options.ddg' => 'DuckDuckGo',


### PR DESCRIPTION
Revives #1535 (closed as stale, original work by @jaycollett — his commit authorship is preserved). Addresses linuxserver/Heimdall-Apps#687.

Adds a **Skip TLS Verification (for self-signed certificates)** boolean to Settings → Advanced. When enabled, `SupportedApps::execute()` sets Guzzle `verify => false`, which covers both enhanced-app live stats and the config Test button (`appTest()` routes through the same client). Default is off; it never forces `verify => true`, so per-app override vars still compose.

One change vs the original PR: it used setting id 15, which `default_tag` has since taken on 2.x — the setting now uses the next free id, 16. New installs get it from the seeder; existing installs pick it up on the next version bump because `AppServiceProvider::setupDatabase()` re-runs `migrate --seed` (idempotent find-or-create per id) — the same mechanism that introduced ids 12–15. The boolean renders automatically on the settings page via `Setting::getEditValueAttribute()`, so no view changes are needed.