### PR TITLE
Fix checkbox config values always returning "1" in Test config

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -4271,7 +4271,12 @@ $.when($.ready).then(function () {
     data.url = apiurl;
     $(".config-item").each(function () {
       var config = $(this).data("config");
-      data[config] = $(this).val();
+      // For checkboxes, use checked state instead of value attribute
+      if ($(this).is(":checkbox")) {
+        data[config] = $(this).is(":checked") ? "1" : "0";
+      } else {
+        data[config] = $(this).val();
+      }
     });
     data.id = $("form[data-item-id]").data("item-id");
     if (data.password && data.password === fakePassword) {

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -310,7 +310,12 @@ $.when($.ready).then(() => {
       data.url = apiurl;
       $(".config-item").each(function () {
         const config = $(this).data("config");
-        data[config] = $(this).val();
+        // For checkboxes, use checked state instead of value attribute
+        if ($(this).is(":checkbox")) {
+          data[config] = $(this).is(":checked") ? "1" : "0";
+        } else {
+          data[config] = $(this).val();
+        }
       });
 
       data.id = $("form[data-item-id]").data("item-id");


### PR DESCRIPTION
Revives #1536 (closed as stale, original work by @jaycollett — his commit authorship is preserved). Fixes linuxserver/Heimdall-Apps#782.

The Test-button config gatherer wrote `$(this).val()` for every `.config-item`; jQuery `.val()` on a checkbox returns its value attribute regardless of checked state, and app config blades pair a hidden input (0) with a checkbox (1) sharing the same `data-config`, so options like `ignore_tls` always tested as "1". Checkboxes now report their checked state ("1"/"0"). Normal form saves were never affected — only the Test path.

Beyond the original PR: Heimdall serves the committed compiled bundle `public/js/app.js`, which #1536 didn't touch, so it would have had no runtime effect until a rebuild. This PR mirrors the fix there; the edit is byte-identical to what `npm run development` emits for that block (a full rebuild was avoided because dependency drift churns ~1200 unrelated lines).

Verified with jsdom + the repo's bundled jQuery against a real hidden+checkbox blade pairing: old code returns "1" checked and unchecked; fixed code returns "1"/"0". ESLint passes.