### PR TITLE
Fix inconsistent SVG tile icon sizes

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -927,9 +927,10 @@ div.create .input input, div.create .input select {
 }
 
 .app-icon {
-  max-width: 60px;
+  width: 60px;
+  height: 60px;
+  object-fit: contain;
   display: block;
-  max-height: 60px;
 }
 
 .sidenav {

--- a/resources/assets/sass/_app.scss
+++ b/resources/assets/sass/_app.scss
@@ -722,9 +722,10 @@ div.create {
 	flex: 0 0 60px;
 }
 .app-icon {
-	max-width: 60px;
+	width: 60px;
+	height: 60px;
+	object-fit: contain;
 	display: block;
-	max-height: 60px;
 }
 
 .sidenav {


### PR DESCRIPTION
Fixes #1582.

## Problem

Mixing icon sources on the dashboard looked broken: SVGs that ship explicit `width`/`height` attributes rendered tiny, while icons without size attributes (e.g. Simple Icons) rendered large.

The cause is `.app-icon` using `max-width`/`max-height: 60px`. `max-*` only caps an image's intrinsic size and never scales it up, so an SVG declaring `width="24"` rendered at 24px, while a dimensionless SVG defaulted large and got capped to 60px.

## Fix

Pin `.app-icon` to a fixed `60px x 60px` box with `object-fit: contain`. The `.app-icon-container` was already a fixed 60x60, so every icon now renders at a consistent size regardless of whether the SVG declares its own dimensions, and `object-fit: contain` preserves aspect ratio so non-square icons are not distorted.

Updated both the SCSS source and the committed compiled CSS. No upscaling regression for the raster fallback (`heimdall-icon-small.png` is 250x250).