### PR TITLE
Fix reordering when tags are treated as categories

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -98,9 +98,17 @@ class ItemController extends Controller
      */
     public function setOrder(Request $request)
     {
-        $order = array_filter($request->input('order'));
-        foreach ($order as $o => $id) {
+        // Drop blanks only: "0" is the home dashboard tag, which is a valid
+        // id when categories are being reordered.
+        $order = array_filter(
+            (array) $request->input('order', []),
+            fn ($id) => $id !== null && $id !== ''
+        );
+        foreach (array_values($order) as $o => $id) {
             $item = Item::find($id);
+            if ($item === null) {
+                continue;
+            }
             $item->order = $o;
             $item->save();
         }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,5 +1,10 @@
-function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
-/*! Sortable 1.15.2 - MIT | git://github.com/SortableJS/Sortable.git */
+function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function _defineProperty(e, r, t) { return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, { value: t, enumerable: !0, configurable: !0, writable: !0 }) : e[r] = t, e; }
+function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
+function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+/*! Sortable 1.15.6 - MIT | git://github.com/SortableJS/Sortable.git */
 !function (t, e) {
   "object" == (typeof exports === "undefined" ? "undefined" : _typeof(exports)) && "undefined" != typeof module ? module.exports = e() : "function" == typeof define && define.amd ? define(e) : (t = t || self).Sortable = e();
 }(this, function () {
@@ -41,9 +46,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       for (var e = 1; e < arguments.length; e++) {
         var n,
           o = arguments[e];
-        for (n in o) {
-          Object.prototype.hasOwnProperty.call(o, n) && (t[n] = o[n]);
-        }
+        for (n in o) Object.prototype.hasOwnProperty.call(o, n) && (t[n] = o[n]);
       }
       return t;
     }).apply(this, arguments);
@@ -53,14 +56,10 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     var n,
       o = function (t, e) {
         if (null == t) return {};
-        for (var n, o = {}, i = Object.keys(t), r = 0; r < i.length; r++) {
-          n = i[r], 0 <= e.indexOf(n) || (o[n] = t[n]);
-        }
+        for (var n, o = {}, i = Object.keys(t), r = 0; r < i.length; r++) n = i[r], 0 <= e.indexOf(n) || (o[n] = t[n]);
         return o;
       }(t, e);
-    if (Object.getOwnPropertySymbols) for (var i = Object.getOwnPropertySymbols(t), r = 0; r < i.length; r++) {
-      n = i[r], 0 <= e.indexOf(n) || Object.prototype.propertyIsEnumerable.call(t, n) && (o[n] = t[n]);
-    }
+    if (Object.getOwnPropertySymbols) for (var i = Object.getOwnPropertySymbols(t), r = 0; r < i.length; r++) n = i[r], 0 <= e.indexOf(n) || Object.prototype.propertyIsEnumerable.call(t, n) && (o[n] = t[n]);
     return o;
   }
   function r(t) {
@@ -80,9 +79,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
   }
   function l(t, e) {
     (null == e || e > t.length) && (e = t.length);
-    for (var n = 0, o = new Array(e); n < e; n++) {
-      o[n] = t[n];
-    }
+    for (var n = 0, o = new Array(e); n < e; n++) o[n] = t[n];
     return o;
   }
   function t(t) {
@@ -92,8 +89,8 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     w = t(/Edge/i),
     s = t(/firefox/i),
     u = t(/safari/i) && !t(/chrome/i) && !t(/android/i),
-    n = t(/iP(ad|od|hone)/i),
-    c = t(/chrome/i) && t(/android/i),
+    c = t(/iP(ad|od|hone)/i),
+    n = t(/chrome/i) && t(/android/i),
     d = {
       capture: !1,
       passive: !1
@@ -101,10 +98,10 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
   function h(t, e, n) {
     t.addEventListener(e, n, !y && d);
   }
-  function f(t, e, n) {
+  function p(t, e, n) {
     t.removeEventListener(e, n, !y && d);
   }
-  function p(t, e) {
+  function f(t, e) {
     if (e && (">" === e[0] && (e = e.substring(1)), t)) try {
       if (t.matches) return t.matches(e);
       if (t.msMatchesSelector) return t.msMatchesSelector(e);
@@ -113,21 +110,23 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       return;
     }
   }
+  function g(t) {
+    return t.host && t !== document && t.host.nodeType ? t.host : t.parentNode;
+  }
   function P(t, e, n, o) {
     if (t) {
       n = n || document;
       do {
-        if (null != e && (">" !== e[0] || t.parentNode === n) && p(t, e) || o && t === n) return t;
-      } while (t !== n && (t = (i = t).host && i !== document && i.host.nodeType ? i.host : i.parentNode));
+        if (null != e && (">" !== e[0] || t.parentNode === n) && f(t, e) || o && t === n) return t;
+      } while (t !== n && (t = g(t)));
     }
-    var i;
     return null;
   }
-  var g,
-    m = /\s+/g;
+  var m,
+    v = /\s+/g;
   function k(t, e, n) {
     var o;
-    t && e && (t.classList ? t.classList[n ? "add" : "remove"](e) : (o = (" " + t.className + " ").replace(m, " ").replace(" " + e + " ", " "), t.className = (o + (n ? " " + e : "")).replace(m, " ")));
+    t && e && (t.classList ? t.classList[n ? "add" : "remove"](e) : (o = (" " + t.className + " ").replace(v, " ").replace(" " + e + " ", " "), t.className = (o + (n ? " " + e : "")).replace(v, " ")));
   }
   function R(t, e, n) {
     var o = t && t.style;
@@ -136,22 +135,20 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       o[e = !(e in o || -1 !== e.indexOf("webkit")) ? "-webkit-" + e : e] = n + ("string" == typeof n ? "" : "px");
     }
   }
-  function v(t, e) {
+  function b(t, e) {
     var n = "";
     if ("string" == typeof t) n = t;else do {
       var o = R(t, "transform");
-    } while ((o && "none" !== o && (n = o + " " + n), !e && (t = t.parentNode)));
+    } while (o && "none" !== o && (n = o + " " + n), !e && (t = t.parentNode));
     var i = window.DOMMatrix || window.WebKitCSSMatrix || window.CSSMatrix || window.MSCSSMatrix;
     return i && new i(n);
   }
-  function b(t, e, n) {
+  function D(t, e, n) {
     if (t) {
       var o = t.getElementsByTagName(e),
         i = 0,
         r = o.length;
-      if (n) for (; i < r; i++) {
-        n(o[i], i);
-      }
+      if (n) for (; i < r; i++) n(o[i], i);
       return o;
     }
     return [];
@@ -176,7 +173,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           break;
         }
       } while (i = i.parentNode);
-      return o && t !== window && (o = (e = v(i || t)) && e.a, t = e && e.d, e && (s = (a /= t) + (u /= t), c = (l /= o) + (d /= o))), {
+      return o && t !== window && (o = (e = b(i || t)) && e.a, t = e && e.d, e && (s = (a /= t) + (u /= t), c = (l /= o) + (d /= o))), {
         top: a,
         left: l,
         bottom: s,
@@ -197,7 +194,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
   }
   function B(t, e, n, o) {
     for (var i = 0, r = 0, a = t.children; r < a.length;) {
-      if ("none" !== a[r].style.display && a[r] !== Ft.ghost && (o || a[r] !== Ft.dragged) && P(a[r], n.draggable, t, !1)) {
+      if ("none" !== a[r].style.display && a[r] !== jt.ghost && (o || a[r] !== jt.dragged) && P(a[r], n.draggable, t, !1)) {
         if (i === e) return a[r];
         i++;
       }
@@ -206,17 +203,13 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     return null;
   }
   function F(t, e) {
-    for (var n = t.lastElementChild; n && (n === Ft.ghost || "none" === R(n, "display") || e && !p(n, e));) {
-      n = n.previousElementSibling;
-    }
+    for (var n = t.lastElementChild; n && (n === jt.ghost || "none" === R(n, "display") || e && !f(n, e));) n = n.previousElementSibling;
     return n || null;
   }
   function j(t, e) {
     var n = 0;
     if (!t || !t.parentNode) return -1;
-    for (; t = t.previousElementSibling;) {
-      "TEMPLATE" === t.nodeName.toUpperCase() || t === Ft.clone || e && !p(t, e) || n++;
-    }
+    for (; t = t.previousElementSibling;) "TEMPLATE" === t.nodeName.toUpperCase() || t === jt.clone || e && !f(t, e) || n++;
     return n;
   }
   function E(t) {
@@ -224,10 +217,10 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       n = 0,
       o = O();
     if (t) do {
-      var i = v(t),
+      var i = b(t),
         r = i.a,
         i = i.d;
-    } while ((e += t.scrollLeft * r, n += t.scrollTop * i, t !== o && (t = t.parentNode)));
+    } while (e += t.scrollLeft * r, n += t.scrollTop * i, t !== o && (t = t.parentNode));
     return [e, n];
   }
   function M(t, e) {
@@ -246,29 +239,29 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     } while (n = n.parentNode);
     return O();
   }
-  function D(t, e) {
+  function S(t, e) {
     return Math.round(t.top) === Math.round(e.top) && Math.round(t.left) === Math.round(e.left) && Math.round(t.height) === Math.round(e.height) && Math.round(t.width) === Math.round(e.width);
   }
-  function S(e, n) {
+  function _(e, n) {
     return function () {
       var t;
-      g || (1 === (t = arguments).length ? e.call(this, t[0]) : e.apply(this, t), g = setTimeout(function () {
-        g = void 0;
+      m || (1 === (t = arguments).length ? e.call(this, t[0]) : e.apply(this, t), m = setTimeout(function () {
+        m = void 0;
       }, n));
     };
   }
   function H(t, e, n) {
     t.scrollLeft += e, t.scrollTop += n;
   }
-  function _(t) {
+  function C(t) {
     var e = window.Polymer,
       n = window.jQuery || window.Zepto;
     return e && e.dom ? e.dom(t).cloneNode(!0) : n ? n(t).clone(!0)[0] : t.cloneNode(!0);
   }
-  function C(t, e) {
+  function T(t, e) {
     R(t, "position", "absolute"), R(t, "top", e.top), R(t, "left", e.left), R(t, "width", e.width), R(t, "height", e.height);
   }
-  function T(t) {
+  function x(t) {
     R(t, "position", ""), R(t, "top", ""), R(t, "left", ""), R(t, "width", ""), R(t, "height", "");
   }
   function L(n, o, i) {
@@ -279,17 +272,17 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     }), r.width = r.right - r.left, r.height = r.bottom - r.top, r.x = r.left, r.y = r.top, r;
   }
   var K = "Sortable" + new Date().getTime();
-  function x() {
+  function A() {
     var e,
       o = [];
     return {
       captureAnimationState: function captureAnimationState() {
         o = [], this.options.animation && [].slice.call(this.el.children).forEach(function (t) {
           var e, n;
-          "none" !== R(t, "display") && t !== Ft.ghost && (o.push({
+          "none" !== R(t, "display") && t !== jt.ghost && (o.push({
             target: t,
             rect: X(t)
-          }), e = I({}, o[o.length - 1].rect), !t.thisAnimationDuration || (n = v(t, !0)) && (e.top -= n.f, e.left -= n.e), t.fromRect = e);
+          }), e = I({}, o[o.length - 1].rect), !t.thisAnimationDuration || (n = b(t, !0)) && (e.top -= n.f, e.left -= n.e), t.fromRect = e);
         });
       },
       addAnimationState: function addAnimationState(t) {
@@ -297,11 +290,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       },
       removeAnimationState: function removeAnimationState(t) {
         o.splice(function (t, e) {
-          for (var n in t) {
-            if (t.hasOwnProperty(n)) for (var o in e) {
-              if (e.hasOwnProperty(o) && e[o] === t[n][o]) return Number(n);
-            }
-          }
+          for (var n in t) if (t.hasOwnProperty(n)) for (var o in e) if (e.hasOwnProperty(o) && e[o] === t[n][o]) return Number(n);
           return -1;
         }(o, {
           target: t
@@ -320,8 +309,8 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
             r = n.prevFromRect,
             a = n.prevToRect,
             l = t.rect,
-            s = v(n, !0);
-          s && (i.top -= s.f, i.left -= s.e), n.toRect = i, n.thisAnimationDuration && D(r, i) && !D(o, i) && (l.top - i.top) / (l.left - i.left) == (o.top - i.top) / (o.left - i.left) && (t = l, s = r, r = a, a = c.options, e = Math.sqrt(Math.pow(s.top - t.top, 2) + Math.pow(s.left - t.left, 2)) / Math.sqrt(Math.pow(s.top - r.top, 2) + Math.pow(s.left - r.left, 2)) * a.animation), D(i, o) || (n.prevFromRect = o, n.prevToRect = i, e = e || c.options.animation, c.animate(n, l, i, e)), e && (u = !0, d = Math.max(d, e), clearTimeout(n.animationResetTimer), n.animationResetTimer = setTimeout(function () {
+            s = b(n, !0);
+          s && (i.top -= s.f, i.left -= s.e), n.toRect = i, n.thisAnimationDuration && S(r, i) && !S(o, i) && (l.top - i.top) / (l.left - i.left) == (o.top - i.top) / (o.left - i.left) && (t = l, s = r, r = a, a = c.options, e = Math.sqrt(Math.pow(s.top - t.top, 2) + Math.pow(s.left - t.left, 2)) / Math.sqrt(Math.pow(s.top - r.top, 2) + Math.pow(s.left - r.left, 2)) * a.animation), S(i, o) || (n.prevFromRect = o, n.prevToRect = i, e = e || c.options.animation, c.animate(n, l, i, e)), e && (u = !0, d = Math.max(d, e), clearTimeout(n.animationResetTimer), n.animationResetTimer = setTimeout(function () {
             n.animationTime = 0, n.prevFromRect = null, n.fromRect = null, n.prevToRect = null, n.thisAnimationDuration = null;
           }, e), n.thisAnimationDuration = e);
         }), clearTimeout(e), u ? e = setTimeout(function () {
@@ -330,24 +319,22 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       },
       animate: function animate(t, e, n, o) {
         var i, r;
-        o && (R(t, "transition", ""), R(t, "transform", ""), i = (r = v(this.el)) && r.a, r = r && r.d, i = (e.left - n.left) / (i || 1), r = (e.top - n.top) / (r || 1), t.animatingX = !!i, t.animatingY = !!r, R(t, "transform", "translate3d(" + i + "px," + r + "px,0)"), this.forRepaintDummy = t.offsetWidth, R(t, "transition", "transform " + o + "ms" + (this.options.easing ? " " + this.options.easing : "")), R(t, "transform", "translate3d(0,0,0)"), "number" == typeof t.animated && clearTimeout(t.animated), t.animated = setTimeout(function () {
+        o && (R(t, "transition", ""), R(t, "transform", ""), i = (r = b(this.el)) && r.a, r = r && r.d, i = (e.left - n.left) / (i || 1), r = (e.top - n.top) / (r || 1), t.animatingX = !!i, t.animatingY = !!r, R(t, "transform", "translate3d(" + i + "px," + r + "px,0)"), this.forRepaintDummy = t.offsetWidth, R(t, "transition", "transform " + o + "ms" + (this.options.easing ? " " + this.options.easing : "")), R(t, "transform", "translate3d(0,0,0)"), "number" == typeof t.animated && clearTimeout(t.animated), t.animated = setTimeout(function () {
           R(t, "transition", ""), R(t, "transform", ""), t.animated = !1, t.animatingX = !1, t.animatingY = !1;
         }, o));
       }
     };
   }
-  var A = [],
-    N = {
+  var N = [],
+    W = {
       initializeByDefault: !0
     },
-    W = {
+    z = {
       mount: function mount(e) {
-        for (var t in N) {
-          !N.hasOwnProperty(t) || t in e || (e[t] = N[t]);
-        }
-        A.forEach(function (t) {
+        for (var t in W) !W.hasOwnProperty(t) || t in e || (e[t] = W[t]);
+        N.forEach(function (t) {
           if (t.pluginName === e.pluginName) throw "Sortable: Cannot mount plugin ".concat(e.pluginName, " more than once");
-        }), A.push(e);
+        }), N.push(e);
       },
       pluginEvent: function pluginEvent(e, n, o) {
         var t = this;
@@ -355,7 +342,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           t.eventCanceled = !0;
         };
         var i = e + "Global";
-        A.forEach(function (t) {
+        N.forEach(function (t) {
           n[t.pluginName] && (n[t.pluginName][i] && n[t.pluginName][i](I({
             sortable: n
           }, o)), n.options[t.pluginName] && n[t.pluginName][e] && n[t.pluginName][e](I({
@@ -364,7 +351,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         });
       },
       initializePlugins: function initializePlugins(n, o, i, t) {
-        for (var e in A.forEach(function (t) {
+        for (var e in N.forEach(function (t) {
           var e = t.pluginName;
           (n.options[e] || t.initializeByDefault) && ((t = new t(n, o, n.options)).sortable = n, t.options = n.options, n[e] = t, a(i, t.defaults));
         }), n.options) {
@@ -374,18 +361,18 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       },
       getEventProperties: function getEventProperties(e, n) {
         var o = {};
-        return A.forEach(function (t) {
+        return N.forEach(function (t) {
           "function" == typeof t.eventProperties && a(o, t.eventProperties.call(n[t.pluginName], e));
         }), o;
       },
       modifyOption: function modifyOption(e, n, o) {
         var i;
-        return A.forEach(function (t) {
+        return N.forEach(function (t) {
           e[t.pluginName] && t.optionListeners && "function" == typeof t.optionListeners[n] && (i = t.optionListeners[n].call(e[t.pluginName], o));
         }), i;
       }
     };
-  function z(t) {
+  function G(t) {
     var e = t.sortable,
       n = t.rootEl,
       o = t.name,
@@ -398,8 +385,8 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       u = t.oldDraggableIndex,
       d = t.newDraggableIndex,
       h = t.originalEvent,
-      f = t.putSortable,
-      p = t.extraEventProperties;
+      p = t.putSortable,
+      f = t.extraEventProperties;
     if (e = e || n && n[K]) {
       var g,
         m = e.options,
@@ -407,45 +394,43 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       !window.CustomEvent || y || w ? (g = document.createEvent("Event")).initEvent(o, !0, !0) : g = new CustomEvent(o, {
         bubbles: !0,
         cancelable: !0
-      }), g.to = a || n, g.from = l || n, g.item = i || n, g.clone = r, g.oldIndex = s, g.newIndex = c, g.oldDraggableIndex = u, g.newDraggableIndex = d, g.originalEvent = h, g.pullMode = f ? f.lastPutMode : void 0;
+      }), g.to = a || n, g.from = l || n, g.item = i || n, g.clone = r, g.oldIndex = s, g.newIndex = c, g.oldDraggableIndex = u, g.newDraggableIndex = d, g.originalEvent = h, g.pullMode = p ? p.lastPutMode : void 0;
       var v,
-        b = I(I({}, p), W.getEventProperties(o, e));
-      for (v in b) {
-        g[v] = b[v];
-      }
+        b = I(I({}, f), z.getEventProperties(o, e));
+      for (v in b) g[v] = b[v];
       n && n.dispatchEvent(g), m[t] && m[t].call(e, g);
     }
   }
-  function G(t, e) {
+  function U(t, e) {
     var n = (o = 2 < arguments.length && void 0 !== arguments[2] ? arguments[2] : {}).evt,
-      o = i(o, U);
-    W.pluginEvent.bind(Ft)(t, e, I({
-      dragEl: V,
-      parentEl: Z,
-      ghostEl: $,
-      rootEl: Q,
-      nextEl: J,
-      lastDownEl: tt,
-      cloneEl: et,
-      cloneHidden: nt,
-      dragStarted: gt,
-      putSortable: st,
-      activeSortable: Ft.active,
+      o = i(o, q);
+    z.pluginEvent.bind(jt)(t, e, I({
+      dragEl: Z,
+      parentEl: $,
+      ghostEl: Q,
+      rootEl: J,
+      nextEl: tt,
+      lastDownEl: et,
+      cloneEl: nt,
+      cloneHidden: ot,
+      dragStarted: mt,
+      putSortable: ct,
+      activeSortable: jt.active,
       originalEvent: n,
-      oldIndex: ot,
-      oldDraggableIndex: rt,
-      newIndex: it,
-      newDraggableIndex: at,
-      hideGhostForTarget: Rt,
-      unhideGhostForTarget: Xt,
+      oldIndex: it,
+      oldDraggableIndex: at,
+      newIndex: rt,
+      newDraggableIndex: lt,
+      hideGhostForTarget: Xt,
+      unhideGhostForTarget: Yt,
       cloneNowHidden: function cloneNowHidden() {
-        nt = !0;
+        ot = !0;
       },
       cloneNowShown: function cloneNowShown() {
-        nt = !1;
+        ot = !1;
       },
       dispatchSortableEvent: function dispatchSortableEvent(t) {
-        q({
+        V({
           sortable: e,
           name: t,
           originalEvent: n
@@ -453,21 +438,20 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       }
     }, o));
   }
-  var U = ["evt"];
-  function q(t) {
-    z(I({
-      putSortable: st,
-      cloneEl: et,
-      targetEl: V,
-      rootEl: Q,
-      oldIndex: ot,
-      oldDraggableIndex: rt,
-      newIndex: it,
-      newDraggableIndex: at
+  var q = ["evt"];
+  function V(t) {
+    G(I({
+      putSortable: ct,
+      cloneEl: nt,
+      targetEl: Z,
+      rootEl: J,
+      oldIndex: it,
+      oldDraggableIndex: at,
+      newIndex: rt,
+      newDraggableIndex: lt
     }, t));
   }
-  var V,
-    Z,
+  var Z,
     $,
     Q,
     J,
@@ -484,33 +468,34 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     ut,
     dt,
     ht,
-    ft,
     pt,
+    ft,
     gt,
     mt,
     vt,
     bt,
     yt,
-    wt = !1,
+    wt,
+    Dt = !1,
     Et = !1,
-    Dt = [],
-    St = !1,
+    St = [],
     _t = !1,
-    Ct = [],
-    Tt = !1,
-    xt = [],
-    Ot = "undefined" != typeof document,
-    Mt = n,
-    At = w || y ? "cssFloat" : "float",
-    Nt = Ot && !c && !n && "draggable" in document.createElement("div"),
-    It = function () {
-      if (Ot) {
+    Ct = !1,
+    Tt = [],
+    xt = !1,
+    Ot = [],
+    Mt = "undefined" != typeof document,
+    At = c,
+    Nt = w || y ? "cssFloat" : "float",
+    It = Mt && !n && !c && "draggable" in document.createElement("div"),
+    Pt = function () {
+      if (Mt) {
         if (y) return !1;
         var t = document.createElement("x");
         return t.style.cssText = "pointer-events:auto", "auto" === t.style.pointerEvents;
       }
     }(),
-    Pt = function Pt(t, e) {
+    kt = function kt(t, e) {
       var n = R(t),
         o = parseInt(n.width) - parseInt(n.paddingLeft) - parseInt(n.paddingRight) - parseInt(n.borderLeftWidth) - parseInt(n.borderRightWidth),
         i = B(t, 0, e),
@@ -525,9 +510,9 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         e = "left" === a["float"] ? "left" : "right";
         return !r || "both" !== l.clear && l.clear !== e ? "horizontal" : "vertical";
       }
-      return i && ("block" === a.display || "flex" === a.display || "table" === a.display || "grid" === a.display || o <= s && "none" === n[At] || r && "none" === n[At] && o < s + t) ? "vertical" : "horizontal";
+      return i && ("block" === a.display || "flex" === a.display || "table" === a.display || "grid" === a.display || o <= s && "none" === n[Nt] || r && "none" === n[Nt] && o < s + t) ? "vertical" : "horizontal";
     },
-    kt = function kt(t) {
+    Rt = function Rt(t) {
       function l(r, a) {
         return function (t, e, n, o) {
           var i = t.options.group.name && e.options.group.name && t.options.group.name === e.options.group.name;
@@ -545,19 +530,19 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         name: n
       }), e.name = n.name, e.checkPull = l(n.pull, !0), e.checkPut = l(n.put), e.revertClone = n.revertClone, t.group = e;
     },
-    Rt = function Rt() {
-      !It && $ && R($, "display", "none");
-    },
     Xt = function Xt() {
-      !It && $ && R($, "display", "");
+      !Pt && Q && R(Q, "display", "none");
+    },
+    Yt = function Yt() {
+      !Pt && Q && R(Q, "display", "");
     };
-  Ot && !c && document.addEventListener("click", function (t) {
+  Mt && !n && document.addEventListener("click", function (t) {
     if (Et) return t.preventDefault(), t.stopPropagation && t.stopPropagation(), t.stopImmediatePropagation && t.stopImmediatePropagation(), Et = !1;
   }, !0);
-  function Yt(t) {
-    if (V) {
+  function Bt(t) {
+    if (Z) {
       t = t.touches ? t.touches[0] : t;
-      var e = (i = t.clientX, r = t.clientY, Dt.some(function (t) {
+      var e = (i = t.clientX, r = t.clientY, St.some(function (t) {
         var e = t[K].options.emptyInsertThreshold;
         if (e && !F(t)) {
           var n = X(t),
@@ -569,18 +554,16 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       if (e) {
         var n,
           o = {};
-        for (n in t) {
-          t.hasOwnProperty(n) && (o[n] = t[n]);
-        }
+        for (n in t) t.hasOwnProperty(n) && (o[n] = t[n]);
         o.target = o.rootEl = e, o.preventDefault = void 0, o.stopPropagation = void 0, e[K]._onDragOver(o);
       }
     }
     var i, r, a;
   }
-  function Bt(t) {
-    V && V.parentNode[K]._isOutsideThisEl(t.target);
+  function Ft(t) {
+    Z && Z.parentNode[K]._isOutsideThisEl(t.target);
   }
-  function Ft(t, e) {
+  function jt(t, e) {
     if (!t || !t.nodeType || 1 !== t.nodeType) throw "Sortable: `el` must be an HTMLElement, not ".concat({}.toString.call(t));
     this.el = t, this.options = e = a({}, e), t[K] = this;
     var n,
@@ -597,7 +580,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         invertedSwapThreshold: null,
         removeCloneOnHide: !0,
         direction: function direction() {
-          return Pt(t, this.options);
+          return kt(t, this.options);
         },
         ghostClass: "sortable-ghost",
         chosenClass: "sortable-chosen",
@@ -624,18 +607,14 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           x: 0,
           y: 0
         },
-        supportPointer: !1 !== Ft.supportPointer && "PointerEvent" in window && !u,
+        supportPointer: !1 !== jt.supportPointer && "PointerEvent" in window && (!u || c),
         emptyInsertThreshold: 5
       };
-    for (n in W.initializePlugins(this, t, i), i) {
-      n in e || (e[n] = i[n]);
-    }
-    for (o in kt(e), this) {
-      "_" === o.charAt(0) && "function" == typeof this[o] && (this[o] = this[o].bind(this));
-    }
-    this.nativeDraggable = !e.forceFallback && Nt, this.nativeDraggable && (this.options.touchStartThreshold = 1), e.supportPointer ? h(t, "pointerdown", this._onTapStart) : (h(t, "mousedown", this._onTapStart), h(t, "touchstart", this._onTapStart)), this.nativeDraggable && (h(t, "dragover", this), h(t, "dragenter", this)), Dt.push(this.el), e.store && e.store.get && this.sort(e.store.get(this) || []), a(this, x());
+    for (n in z.initializePlugins(this, t, i), i) n in e || (e[n] = i[n]);
+    for (o in Rt(e), this) "_" === o.charAt(0) && "function" == typeof this[o] && (this[o] = this[o].bind(this));
+    this.nativeDraggable = !e.forceFallback && It, this.nativeDraggable && (this.options.touchStartThreshold = 1), e.supportPointer ? h(t, "pointerdown", this._onTapStart) : (h(t, "mousedown", this._onTapStart), h(t, "touchstart", this._onTapStart)), this.nativeDraggable && (h(t, "dragover", this), h(t, "dragenter", this)), St.push(this.el), e.store && e.store.get && this.sort(e.store.get(this) || []), a(this, A());
   }
-  function jt(t, e, n, o, i, r, a, l) {
+  function Ht(t, e, n, o, i, r, a, l) {
     var s,
       c,
       u = t[K],
@@ -645,25 +624,25 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       cancelable: !0
     }), s.to = e, s.from = t, s.dragged = n, s.draggedRect = o, s.related = i || e, s.relatedRect = r || X(e), s.willInsertAfter = l, s.originalEvent = a, t.dispatchEvent(s), c = d ? d.call(u, s, a) : c;
   }
-  function Ht(t) {
+  function Lt(t) {
     t.draggable = !1;
   }
-  function Lt() {
-    Tt = !1;
-  }
-  function Kt(t) {
-    return setTimeout(t, 0);
+  function Kt() {
+    xt = !1;
   }
   function Wt(t) {
+    return setTimeout(t, 0);
+  }
+  function zt(t) {
     return clearTimeout(t);
   }
-  Ft.prototype = {
-    constructor: Ft,
+  jt.prototype = {
+    constructor: jt,
     _isOutsideThisEl: function _isOutsideThisEl(t) {
-      this.el.contains(t) || t === this.el || (mt = null);
+      this.el.contains(t) || t === this.el || (vt = null);
     },
     _getDirection: function _getDirection(t, e) {
-      return "function" == typeof this.options.direction ? this.options.direction.call(this, t, e, V) : this.options.direction;
+      return "function" == typeof this.options.direction ? this.options.direction.call(this, t, e, Z) : this.options.direction;
     },
     _onTapStart: function _onTapStart(e) {
       if (e.cancelable) {
@@ -677,37 +656,37 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           s = e.target.shadowRoot && (e.path && e.path[0] || e.composedPath && e.composedPath()[0]) || l,
           c = t.filter;
         if (!function (t) {
-          xt.length = 0;
+          Ot.length = 0;
           var e = t.getElementsByTagName("input"),
             n = e.length;
           for (; n--;) {
             var o = e[n];
-            o.checked && xt.push(o);
+            o.checked && Ot.push(o);
           }
-        }(o), !V && !(/mousedown|pointerdown/.test(r) && 0 !== e.button || t.disabled) && !s.isContentEditable && (this.nativeDraggable || !u || !l || "SELECT" !== l.tagName.toUpperCase()) && !((l = P(l, t.draggable, o, !1)) && l.animated || tt === l)) {
-          if (ot = j(l), rt = j(l, t.draggable), "function" == typeof c) {
-            if (c.call(this, e, l, this)) return q({
+        }(o), !Z && !(/mousedown|pointerdown/.test(r) && 0 !== e.button || t.disabled) && !s.isContentEditable && (this.nativeDraggable || !u || !l || "SELECT" !== l.tagName.toUpperCase()) && !((l = P(l, t.draggable, o, !1)) && l.animated || et === l)) {
+          if (it = j(l), at = j(l, t.draggable), "function" == typeof c) {
+            if (c.call(this, e, l, this)) return V({
               sortable: n,
               rootEl: s,
               name: "filter",
               targetEl: l,
               toEl: o,
               fromEl: o
-            }), G("filter", n, {
+            }), U("filter", n, {
               evt: e
-            }), void (i && e.cancelable && e.preventDefault());
+            }), void (i && e.preventDefault());
           } else if (c = c && c.split(",").some(function (t) {
-            if (t = P(s, t.trim(), o, !1)) return q({
+            if (t = P(s, t.trim(), o, !1)) return V({
               sortable: n,
               rootEl: t,
               name: "filter",
               targetEl: l,
               fromEl: o,
               toEl: o
-            }), G("filter", n, {
+            }), U("filter", n, {
               evt: e
             }), !0;
-          })) return void (i && e.cancelable && e.preventDefault());
+          })) return void (i && e.preventDefault());
           t.handle && !P(s, t.handle, o, !1) || this._prepareDragStart(e, a, l);
         }
       }
@@ -718,122 +697,118 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         r = i.el,
         a = i.options,
         l = r.ownerDocument;
-      n && !V && n.parentNode === r && (o = X(n), Q = r, Z = (V = n).parentNode, J = V.nextSibling, tt = n, lt = a.group, ct = {
-        target: Ft.dragged = V,
+      n && !Z && n.parentNode === r && (o = X(n), J = r, $ = (Z = n).parentNode, tt = Z.nextSibling, et = n, st = a.group, ut = {
+        target: jt.dragged = Z,
         clientX: (e || t).clientX,
         clientY: (e || t).clientY
-      }, ft = ct.clientX - o.left, pt = ct.clientY - o.top, this._lastX = (e || t).clientX, this._lastY = (e || t).clientY, V.style["will-change"] = "all", o = function o() {
-        G("delayEnded", i, {
+      }, ft = ut.clientX - o.left, gt = ut.clientY - o.top, this._lastX = (e || t).clientX, this._lastY = (e || t).clientY, Z.style["will-change"] = "all", o = function o() {
+        U("delayEnded", i, {
           evt: t
-        }), Ft.eventCanceled ? i._onDrop() : (i._disableDelayedDragEvents(), !s && i.nativeDraggable && (V.draggable = !0), i._triggerDragStart(t, e), q({
+        }), jt.eventCanceled ? i._onDrop() : (i._disableDelayedDragEvents(), !s && i.nativeDraggable && (Z.draggable = !0), i._triggerDragStart(t, e), V({
           sortable: i,
           name: "choose",
           originalEvent: t
-        }), k(V, a.chosenClass, !0));
+        }), k(Z, a.chosenClass, !0));
       }, a.ignore.split(",").forEach(function (t) {
-        b(V, t.trim(), Ht);
-      }), h(l, "dragover", Yt), h(l, "mousemove", Yt), h(l, "touchmove", Yt), h(l, "mouseup", i._onDrop), h(l, "touchend", i._onDrop), h(l, "touchcancel", i._onDrop), s && this.nativeDraggable && (this.options.touchStartThreshold = 4, V.draggable = !0), G("delayStart", this, {
+        D(Z, t.trim(), Lt);
+      }), h(l, "dragover", Bt), h(l, "mousemove", Bt), h(l, "touchmove", Bt), a.supportPointer ? (h(l, "pointerup", i._onDrop), this.nativeDraggable || h(l, "pointercancel", i._onDrop)) : (h(l, "mouseup", i._onDrop), h(l, "touchend", i._onDrop), h(l, "touchcancel", i._onDrop)), s && this.nativeDraggable && (this.options.touchStartThreshold = 4, Z.draggable = !0), U("delayStart", this, {
         evt: t
-      }), !a.delay || a.delayOnTouchOnly && !e || this.nativeDraggable && (w || y) ? o() : Ft.eventCanceled ? this._onDrop() : (h(l, "mouseup", i._disableDelayedDrag), h(l, "touchend", i._disableDelayedDrag), h(l, "touchcancel", i._disableDelayedDrag), h(l, "mousemove", i._delayedDragTouchMoveHandler), h(l, "touchmove", i._delayedDragTouchMoveHandler), a.supportPointer && h(l, "pointermove", i._delayedDragTouchMoveHandler), i._dragStartTimer = setTimeout(o, a.delay)));
+      }), !a.delay || a.delayOnTouchOnly && !e || this.nativeDraggable && (w || y) ? o() : jt.eventCanceled ? this._onDrop() : (a.supportPointer ? (h(l, "pointerup", i._disableDelayedDrag), h(l, "pointercancel", i._disableDelayedDrag)) : (h(l, "mouseup", i._disableDelayedDrag), h(l, "touchend", i._disableDelayedDrag), h(l, "touchcancel", i._disableDelayedDrag)), h(l, "mousemove", i._delayedDragTouchMoveHandler), h(l, "touchmove", i._delayedDragTouchMoveHandler), a.supportPointer && h(l, "pointermove", i._delayedDragTouchMoveHandler), i._dragStartTimer = setTimeout(o, a.delay)));
     },
     _delayedDragTouchMoveHandler: function _delayedDragTouchMoveHandler(t) {
       t = t.touches ? t.touches[0] : t;
       Math.max(Math.abs(t.clientX - this._lastX), Math.abs(t.clientY - this._lastY)) >= Math.floor(this.options.touchStartThreshold / (this.nativeDraggable && window.devicePixelRatio || 1)) && this._disableDelayedDrag();
     },
     _disableDelayedDrag: function _disableDelayedDrag() {
-      V && Ht(V), clearTimeout(this._dragStartTimer), this._disableDelayedDragEvents();
+      Z && Lt(Z), clearTimeout(this._dragStartTimer), this._disableDelayedDragEvents();
     },
     _disableDelayedDragEvents: function _disableDelayedDragEvents() {
       var t = this.el.ownerDocument;
-      f(t, "mouseup", this._disableDelayedDrag), f(t, "touchend", this._disableDelayedDrag), f(t, "touchcancel", this._disableDelayedDrag), f(t, "mousemove", this._delayedDragTouchMoveHandler), f(t, "touchmove", this._delayedDragTouchMoveHandler), f(t, "pointermove", this._delayedDragTouchMoveHandler);
+      p(t, "mouseup", this._disableDelayedDrag), p(t, "touchend", this._disableDelayedDrag), p(t, "touchcancel", this._disableDelayedDrag), p(t, "pointerup", this._disableDelayedDrag), p(t, "pointercancel", this._disableDelayedDrag), p(t, "mousemove", this._delayedDragTouchMoveHandler), p(t, "touchmove", this._delayedDragTouchMoveHandler), p(t, "pointermove", this._delayedDragTouchMoveHandler);
     },
     _triggerDragStart: function _triggerDragStart(t, e) {
-      e = e || "touch" == t.pointerType && t, !this.nativeDraggable || e ? this.options.supportPointer ? h(document, "pointermove", this._onTouchMove) : h(document, e ? "touchmove" : "mousemove", this._onTouchMove) : (h(V, "dragend", this), h(Q, "dragstart", this._onDragStart));
+      e = e || "touch" == t.pointerType && t, !this.nativeDraggable || e ? this.options.supportPointer ? h(document, "pointermove", this._onTouchMove) : h(document, e ? "touchmove" : "mousemove", this._onTouchMove) : (h(Z, "dragend", this), h(J, "dragstart", this._onDragStart));
       try {
-        document.selection ? Kt(function () {
+        document.selection ? Wt(function () {
           document.selection.empty();
         }) : window.getSelection().removeAllRanges();
       } catch (t) {}
     },
     _dragStarted: function _dragStarted(t, e) {
       var n;
-      wt = !1, Q && V ? (G("dragStarted", this, {
+      Dt = !1, J && Z ? (U("dragStarted", this, {
         evt: e
-      }), this.nativeDraggable && h(document, "dragover", Bt), n = this.options, t || k(V, n.dragClass, !1), k(V, n.ghostClass, !0), Ft.active = this, t && this._appendGhost(), q({
+      }), this.nativeDraggable && h(document, "dragover", Ft), n = this.options, t || k(Z, n.dragClass, !1), k(Z, n.ghostClass, !0), jt.active = this, t && this._appendGhost(), V({
         sortable: this,
         name: "start",
         originalEvent: e
       })) : this._nulling();
     },
     _emulateDragOver: function _emulateDragOver() {
-      if (ut) {
-        this._lastX = ut.clientX, this._lastY = ut.clientY, Rt();
-        for (var t = document.elementFromPoint(ut.clientX, ut.clientY), e = t; t && t.shadowRoot && (t = t.shadowRoot.elementFromPoint(ut.clientX, ut.clientY)) !== e;) {
-          e = t;
-        }
-        if (V.parentNode[K]._isOutsideThisEl(t), e) do {
+      if (dt) {
+        this._lastX = dt.clientX, this._lastY = dt.clientY, Xt();
+        for (var t = document.elementFromPoint(dt.clientX, dt.clientY), e = t; t && t.shadowRoot && (t = t.shadowRoot.elementFromPoint(dt.clientX, dt.clientY)) !== e;) e = t;
+        if (Z.parentNode[K]._isOutsideThisEl(t), e) do {
           if (e[K]) if (e[K]._onDragOver({
-            clientX: ut.clientX,
-            clientY: ut.clientY,
+            clientX: dt.clientX,
+            clientY: dt.clientY,
             target: t,
             rootEl: e
           }) && !this.options.dragoverBubble) break;
-        } while (e = (t = e).parentNode);
-        Xt();
+        } while (e = g(t = e));
+        Yt();
       }
     },
     _onTouchMove: function _onTouchMove(t) {
-      if (ct) {
+      if (ut) {
         var e = this.options,
           n = e.fallbackTolerance,
           o = e.fallbackOffset,
           i = t.touches ? t.touches[0] : t,
-          r = $ && v($, !0),
-          a = $ && r && r.a,
-          l = $ && r && r.d,
-          e = Mt && yt && E(yt),
-          a = (i.clientX - ct.clientX + o.x) / (a || 1) + (e ? e[0] - Ct[0] : 0) / (a || 1),
-          l = (i.clientY - ct.clientY + o.y) / (l || 1) + (e ? e[1] - Ct[1] : 0) / (l || 1);
-        if (!Ft.active && !wt) {
+          r = Q && b(Q, !0),
+          a = Q && r && r.a,
+          l = Q && r && r.d,
+          e = At && wt && E(wt),
+          a = (i.clientX - ut.clientX + o.x) / (a || 1) + (e ? e[0] - Tt[0] : 0) / (a || 1),
+          l = (i.clientY - ut.clientY + o.y) / (l || 1) + (e ? e[1] - Tt[1] : 0) / (l || 1);
+        if (!jt.active && !Dt) {
           if (n && Math.max(Math.abs(i.clientX - this._lastX), Math.abs(i.clientY - this._lastY)) < n) return;
           this._onDragStart(t, !0);
         }
-        $ && (r ? (r.e += a - (dt || 0), r.f += l - (ht || 0)) : r = {
+        Q && (r ? (r.e += a - (ht || 0), r.f += l - (pt || 0)) : r = {
           a: 1,
           b: 0,
           c: 0,
           d: 1,
           e: a,
           f: l
-        }, r = "matrix(".concat(r.a, ",").concat(r.b, ",").concat(r.c, ",").concat(r.d, ",").concat(r.e, ",").concat(r.f, ")"), R($, "webkitTransform", r), R($, "mozTransform", r), R($, "msTransform", r), R($, "transform", r), dt = a, ht = l, ut = i), t.cancelable && t.preventDefault();
+        }, r = "matrix(".concat(r.a, ",").concat(r.b, ",").concat(r.c, ",").concat(r.d, ",").concat(r.e, ",").concat(r.f, ")"), R(Q, "webkitTransform", r), R(Q, "mozTransform", r), R(Q, "msTransform", r), R(Q, "transform", r), ht = a, pt = l, dt = i), t.cancelable && t.preventDefault();
       }
     },
     _appendGhost: function _appendGhost() {
-      if (!$) {
-        var t = this.options.fallbackOnBody ? document.body : Q,
-          e = X(V, !0, Mt, !0, t),
+      if (!Q) {
+        var t = this.options.fallbackOnBody ? document.body : J,
+          e = X(Z, !0, At, !0, t),
           n = this.options;
-        if (Mt) {
-          for (yt = t; "static" === R(yt, "position") && "none" === R(yt, "transform") && yt !== document;) {
-            yt = yt.parentNode;
-          }
-          yt !== document.body && yt !== document.documentElement ? (yt === document && (yt = O()), e.top += yt.scrollTop, e.left += yt.scrollLeft) : yt = O(), Ct = E(yt);
+        if (At) {
+          for (wt = t; "static" === R(wt, "position") && "none" === R(wt, "transform") && wt !== document;) wt = wt.parentNode;
+          wt !== document.body && wt !== document.documentElement ? (wt === document && (wt = O()), e.top += wt.scrollTop, e.left += wt.scrollLeft) : wt = O(), Tt = E(wt);
         }
-        k($ = V.cloneNode(!0), n.ghostClass, !1), k($, n.fallbackClass, !0), k($, n.dragClass, !0), R($, "transition", ""), R($, "transform", ""), R($, "box-sizing", "border-box"), R($, "margin", 0), R($, "top", e.top), R($, "left", e.left), R($, "width", e.width), R($, "height", e.height), R($, "opacity", "0.8"), R($, "position", Mt ? "absolute" : "fixed"), R($, "zIndex", "100000"), R($, "pointerEvents", "none"), Ft.ghost = $, t.appendChild($), R($, "transform-origin", ft / parseInt($.style.width) * 100 + "% " + pt / parseInt($.style.height) * 100 + "%");
+        k(Q = Z.cloneNode(!0), n.ghostClass, !1), k(Q, n.fallbackClass, !0), k(Q, n.dragClass, !0), R(Q, "transition", ""), R(Q, "transform", ""), R(Q, "box-sizing", "border-box"), R(Q, "margin", 0), R(Q, "top", e.top), R(Q, "left", e.left), R(Q, "width", e.width), R(Q, "height", e.height), R(Q, "opacity", "0.8"), R(Q, "position", At ? "absolute" : "fixed"), R(Q, "zIndex", "100000"), R(Q, "pointerEvents", "none"), jt.ghost = Q, t.appendChild(Q), R(Q, "transform-origin", ft / parseInt(Q.style.width) * 100 + "% " + gt / parseInt(Q.style.height) * 100 + "%");
       }
     },
     _onDragStart: function _onDragStart(t, e) {
       var n = this,
         o = t.dataTransfer,
         i = n.options;
-      G("dragStart", this, {
+      U("dragStart", this, {
         evt: t
-      }), Ft.eventCanceled ? this._onDrop() : (G("setupClone", this), Ft.eventCanceled || ((et = _(V)).removeAttribute("id"), et.draggable = !1, et.style["will-change"] = "", this._hideClone(), k(et, this.options.chosenClass, !1), Ft.clone = et), n.cloneId = Kt(function () {
-        G("clone", n), Ft.eventCanceled || (n.options.removeCloneOnHide || Q.insertBefore(et, V), n._hideClone(), q({
+      }), jt.eventCanceled ? this._onDrop() : (U("setupClone", this), jt.eventCanceled || ((nt = C(Z)).removeAttribute("id"), nt.draggable = !1, nt.style["will-change"] = "", this._hideClone(), k(nt, this.options.chosenClass, !1), jt.clone = nt), n.cloneId = Wt(function () {
+        U("clone", n), jt.eventCanceled || (n.options.removeCloneOnHide || J.insertBefore(nt, Z), n._hideClone(), V({
           sortable: n,
           name: "clone"
         }));
-      }), e || k(V, i.dragClass, !0), e ? (Et = !0, n._loopId = setInterval(n._emulateDragOver, 50)) : (f(document, "mouseup", n._onDrop), f(document, "touchend", n._onDrop), f(document, "touchcancel", n._onDrop), o && (o.effectAllowed = "move", i.setData && i.setData.call(n, o, V)), h(document, "drop", n), R(V, "transform", "translateZ(0)")), wt = !0, n._dragStartId = Kt(n._dragStarted.bind(n, e, t)), h(document, "selectstart", n), gt = !0, u && R(document.body, "user-select", "none"));
+      }), e || k(Z, i.dragClass, !0), e ? (Et = !0, n._loopId = setInterval(n._emulateDragOver, 50)) : (p(document, "mouseup", n._onDrop), p(document, "touchend", n._onDrop), p(document, "touchcancel", n._onDrop), o && (o.effectAllowed = "move", i.setData && i.setData.call(n, o, Z)), h(document, "drop", n), R(Z, "transform", "translateZ(0)")), Dt = !0, n._dragStartId = Wt(n._dragStarted.bind(n, e, t)), h(document, "selectstart", n), mt = !0, window.getSelection().removeAllRanges(), u && R(document.body, "user-select", "none"));
     },
     _onDragOver: function _onDragOver(n) {
       var o,
@@ -845,167 +820,165 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         l = n.target,
         s = this.options,
         c = s.group,
-        u = Ft.active,
-        d = lt === c,
+        u = jt.active,
+        d = st === c,
         h = s.sort,
-        f = st || u,
-        p = this,
+        p = ct || u,
+        f = this,
         g = !1;
-      if (!Tt) {
-        if (void 0 !== n.preventDefault && n.cancelable && n.preventDefault(), l = P(l, s.draggable, a, !0), O("dragOver"), Ft.eventCanceled) return g;
-        if (V.contains(n.target) || l.animated && l.animatingX && l.animatingY || p._ignoreWhileAnimating === l) return A(!1);
-        if (Et = !1, u && !s.disabled && (d ? h || (i = Z !== Q) : st === this || (this.lastPutMode = lt.checkPull(this, u, V, n)) && c.checkPut(this, u, V, n))) {
-          if (r = "vertical" === this._getDirection(n, l), o = X(V), O("dragOverValid"), Ft.eventCanceled) return g;
-          if (i) return Z = Q, M(), this._hideClone(), O("revert"), Ft.eventCanceled || (J ? Q.insertBefore(V, J) : Q.appendChild(V)), A(!0);
+      if (!xt) {
+        if (void 0 !== n.preventDefault && n.cancelable && n.preventDefault(), l = P(l, s.draggable, a, !0), O("dragOver"), jt.eventCanceled) return g;
+        if (Z.contains(n.target) || l.animated && l.animatingX && l.animatingY || f._ignoreWhileAnimating === l) return A(!1);
+        if (Et = !1, u && !s.disabled && (d ? h || (i = $ !== J) : ct === this || (this.lastPutMode = st.checkPull(this, u, Z, n)) && c.checkPut(this, u, Z, n))) {
+          if (r = "vertical" === this._getDirection(n, l), o = X(Z), O("dragOverValid"), jt.eventCanceled) return g;
+          if (i) return $ = J, M(), this._hideClone(), O("revert"), jt.eventCanceled || (tt ? J.insertBefore(Z, tt) : J.appendChild(Z)), A(!0);
           var m = F(a, s.draggable);
-          if (m && (S = n, c = r, x = X(F((D = this).el, D.options.draggable)), D = L(D.el, D.options, $), !(c ? S.clientX > D.right + 10 || S.clientY > x.bottom && S.clientX > x.left : S.clientY > D.bottom + 10 || S.clientX > x.right && S.clientY > x.top) || m.animated)) {
-            if (m && (t = n, e = r, C = X(B((_ = this).el, 0, _.options, !0)), _ = L(_.el, _.options, $), e ? t.clientX < _.left - 10 || t.clientY < C.top && t.clientX < C.right : t.clientY < _.top - 10 || t.clientY < C.bottom && t.clientX < C.left)) {
+          if (m && (S = n, c = r, x = X(F((E = this).el, E.options.draggable)), E = L(E.el, E.options, Q), !(c ? S.clientX > E.right + 10 || S.clientY > x.bottom && S.clientX > x.left : S.clientY > E.bottom + 10 || S.clientX > x.right && S.clientY > x.top) || m.animated)) {
+            if (m && (t = n, e = r, C = X(B((_ = this).el, 0, _.options, !0)), _ = L(_.el, _.options, Q), e ? t.clientX < _.left - 10 || t.clientY < C.top && t.clientX < C.right : t.clientY < _.top - 10 || t.clientY < C.bottom && t.clientX < C.left)) {
               var v = B(a, 0, s, !0);
-              if (v === V) return A(!1);
-              if (E = X(l = v), !1 !== jt(Q, a, V, o, l, E, n, !1)) return M(), a.insertBefore(V, v), Z = a, N(), A(!0);
+              if (v === Z) return A(!1);
+              if (D = X(l = v), !1 !== Ht(J, a, Z, o, l, D, n, !1)) return M(), a.insertBefore(Z, v), $ = a, N(), A(!0);
             } else if (l.parentNode === a) {
               var b,
                 y,
                 w,
-                E = X(l),
-                D = V.parentNode !== a,
-                S = (S = V.animated && V.toRect || o, x = l.animated && l.toRect || E, _ = (e = r) ? S.left : S.top, t = e ? S.right : S.bottom, C = e ? S.width : S.height, v = e ? x.left : x.top, S = e ? x.right : x.bottom, x = e ? x.width : x.height, !(_ === v || t === S || _ + C / 2 === v + x / 2)),
+                D = X(l),
+                E = Z.parentNode !== a,
+                S = (S = Z.animated && Z.toRect || o, x = l.animated && l.toRect || D, _ = (e = r) ? S.left : S.top, t = e ? S.right : S.bottom, C = e ? S.width : S.height, v = e ? x.left : x.top, S = e ? x.right : x.bottom, x = e ? x.width : x.height, !(_ === v || t === S || _ + C / 2 === v + x / 2)),
                 _ = r ? "top" : "left",
-                C = Y(l, "top", "top") || Y(V, "top", "top"),
+                C = Y(l, "top", "top") || Y(Z, "top", "top"),
                 v = C ? C.scrollTop : void 0;
-              if (mt !== l && (y = E[_], St = !1, _t = !S && s.invertSwap || D), 0 !== (b = function (t, e, n, o, i, r, a, l) {
+              if (vt !== l && (y = D[_], _t = !1, Ct = !S && s.invertSwap || E), 0 !== (b = function (t, e, n, o, i, r, a, l) {
                 var s = o ? t.clientY : t.clientX,
                   c = o ? n.height : n.width,
                   t = o ? n.top : n.left,
                   o = o ? n.bottom : n.right,
                   n = !1;
-                if (!a) if (l && bt < c * i) {
-                  if (St = !St && (1 === vt ? t + c * r / 2 < s : s < o - c * r / 2) ? !0 : St) n = !0;else if (1 === vt ? s < t + bt : o - bt < s) return -vt;
+                if (!a) if (l && yt < c * i) {
+                  if (_t = !_t && (1 === bt ? t + c * r / 2 < s : s < o - c * r / 2) ? !0 : _t) n = !0;else if (1 === bt ? s < t + yt : o - yt < s) return -bt;
                 } else if (t + c * (1 - i) / 2 < s && s < o - c * (1 - i) / 2) return function (t) {
-                  return j(V) < j(t) ? 1 : -1;
+                  return j(Z) < j(t) ? 1 : -1;
                 }(e);
                 if ((n = n || a) && (s < t + c * r / 2 || o - c * r / 2 < s)) return t + c / 2 < s ? 1 : -1;
                 return 0;
-              }(n, l, E, r, S ? 1 : s.swapThreshold, null == s.invertedSwapThreshold ? s.swapThreshold : s.invertedSwapThreshold, _t, mt === l))) for (var T = j(V); (w = Z.children[T -= b]) && ("none" === R(w, "display") || w === $);) {
-                ;
-              }
+              }(n, l, D, r, S ? 1 : s.swapThreshold, null == s.invertedSwapThreshold ? s.swapThreshold : s.invertedSwapThreshold, Ct, vt === l))) for (var T = j(Z); (w = $.children[T -= b]) && ("none" === R(w, "display") || w === Q););
               if (0 === b || w === l) return A(!1);
-              vt = b;
-              var x = (mt = l).nextElementSibling,
-                D = !1,
-                S = jt(Q, a, V, o, l, E, n, D = 1 === b);
-              if (!1 !== S) return 1 !== S && -1 !== S || (D = 1 === S), Tt = !0, setTimeout(Lt, 30), M(), D && !x ? a.appendChild(V) : l.parentNode.insertBefore(V, D ? x : l), C && H(C, 0, v - C.scrollTop), Z = V.parentNode, void 0 === y || _t || (bt = Math.abs(y - X(l)[_])), N(), A(!0);
+              bt = b;
+              var x = (vt = l).nextElementSibling,
+                E = !1,
+                S = Ht(J, a, Z, o, l, D, n, E = 1 === b);
+              if (!1 !== S) return 1 !== S && -1 !== S || (E = 1 === S), xt = !0, setTimeout(Kt, 30), M(), E && !x ? a.appendChild(Z) : l.parentNode.insertBefore(Z, E ? x : l), C && H(C, 0, v - C.scrollTop), $ = Z.parentNode, void 0 === y || Ct || (yt = Math.abs(y - X(l)[_])), N(), A(!0);
             }
           } else {
-            if (m === V) return A(!1);
-            if ((l = m && a === n.target ? m : l) && (E = X(l)), !1 !== jt(Q, a, V, o, l, E, n, !!l)) return M(), m && m.nextSibling ? a.insertBefore(V, m.nextSibling) : a.appendChild(V), Z = a, N(), A(!0);
+            if (m === Z) return A(!1);
+            if ((l = m && a === n.target ? m : l) && (D = X(l)), !1 !== Ht(J, a, Z, o, l, D, n, !!l)) return M(), m && m.nextSibling ? a.insertBefore(Z, m.nextSibling) : a.appendChild(Z), $ = a, N(), A(!0);
           }
-          if (a.contains(V)) return A(!1);
+          if (a.contains(Z)) return A(!1);
         }
         return !1;
       }
       function O(t, e) {
-        G(t, p, I({
+        U(t, f, I({
           evt: n,
           isOwner: d,
           axis: r ? "vertical" : "horizontal",
           revert: i,
           dragRect: o,
-          targetRect: E,
+          targetRect: D,
           canSort: h,
-          fromSortable: f,
+          fromSortable: p,
           target: l,
           completed: A,
           onMove: function onMove(t, e) {
-            return jt(Q, a, V, o, t, X(t), n, e);
+            return Ht(J, a, Z, o, t, X(t), n, e);
           },
           changed: N
         }, e));
       }
       function M() {
-        O("dragOverAnimationCapture"), p.captureAnimationState(), p !== f && f.captureAnimationState();
+        O("dragOverAnimationCapture"), f.captureAnimationState(), f !== p && p.captureAnimationState();
       }
       function A(t) {
         return O("dragOverCompleted", {
           insertion: t
-        }), t && (d ? u._hideClone() : u._showClone(p), p !== f && (k(V, (st || u).options.ghostClass, !1), k(V, s.ghostClass, !0)), st !== p && p !== Ft.active ? st = p : p === Ft.active && st && (st = null), f === p && (p._ignoreWhileAnimating = l), p.animateAll(function () {
-          O("dragOverAnimationComplete"), p._ignoreWhileAnimating = null;
-        }), p !== f && (f.animateAll(), f._ignoreWhileAnimating = null)), (l === V && !V.animated || l === a && !l.animated) && (mt = null), s.dragoverBubble || n.rootEl || l === document || (V.parentNode[K]._isOutsideThisEl(n.target), t || Yt(n)), !s.dragoverBubble && n.stopPropagation && n.stopPropagation(), g = !0;
+        }), t && (d ? u._hideClone() : u._showClone(f), f !== p && (k(Z, (ct || u).options.ghostClass, !1), k(Z, s.ghostClass, !0)), ct !== f && f !== jt.active ? ct = f : f === jt.active && ct && (ct = null), p === f && (f._ignoreWhileAnimating = l), f.animateAll(function () {
+          O("dragOverAnimationComplete"), f._ignoreWhileAnimating = null;
+        }), f !== p && (p.animateAll(), p._ignoreWhileAnimating = null)), (l === Z && !Z.animated || l === a && !l.animated) && (vt = null), s.dragoverBubble || n.rootEl || l === document || (Z.parentNode[K]._isOutsideThisEl(n.target), t || Bt(n)), !s.dragoverBubble && n.stopPropagation && n.stopPropagation(), g = !0;
       }
       function N() {
-        it = j(V), at = j(V, s.draggable), q({
-          sortable: p,
+        rt = j(Z), lt = j(Z, s.draggable), V({
+          sortable: f,
           name: "change",
           toEl: a,
-          newIndex: it,
-          newDraggableIndex: at,
+          newIndex: rt,
+          newDraggableIndex: lt,
           originalEvent: n
         });
       }
     },
     _ignoreWhileAnimating: null,
     _offMoveEvents: function _offMoveEvents() {
-      f(document, "mousemove", this._onTouchMove), f(document, "touchmove", this._onTouchMove), f(document, "pointermove", this._onTouchMove), f(document, "dragover", Yt), f(document, "mousemove", Yt), f(document, "touchmove", Yt);
+      p(document, "mousemove", this._onTouchMove), p(document, "touchmove", this._onTouchMove), p(document, "pointermove", this._onTouchMove), p(document, "dragover", Bt), p(document, "mousemove", Bt), p(document, "touchmove", Bt);
     },
     _offUpEvents: function _offUpEvents() {
       var t = this.el.ownerDocument;
-      f(t, "mouseup", this._onDrop), f(t, "touchend", this._onDrop), f(t, "pointerup", this._onDrop), f(t, "touchcancel", this._onDrop), f(document, "selectstart", this);
+      p(t, "mouseup", this._onDrop), p(t, "touchend", this._onDrop), p(t, "pointerup", this._onDrop), p(t, "pointercancel", this._onDrop), p(t, "touchcancel", this._onDrop), p(document, "selectstart", this);
     },
     _onDrop: function _onDrop(t) {
       var e = this.el,
         n = this.options;
-      it = j(V), at = j(V, n.draggable), G("drop", this, {
+      rt = j(Z), lt = j(Z, n.draggable), U("drop", this, {
         evt: t
-      }), Z = V && V.parentNode, it = j(V), at = j(V, n.draggable), Ft.eventCanceled || (St = _t = wt = !1, clearInterval(this._loopId), clearTimeout(this._dragStartTimer), Wt(this.cloneId), Wt(this._dragStartId), this.nativeDraggable && (f(document, "drop", this), f(e, "dragstart", this._onDragStart)), this._offMoveEvents(), this._offUpEvents(), u && R(document.body, "user-select", ""), R(V, "transform", ""), t && (gt && (t.cancelable && t.preventDefault(), n.dropBubble || t.stopPropagation()), $ && $.parentNode && $.parentNode.removeChild($), (Q === Z || st && "clone" !== st.lastPutMode) && et && et.parentNode && et.parentNode.removeChild(et), V && (this.nativeDraggable && f(V, "dragend", this), Ht(V), V.style["will-change"] = "", gt && !wt && k(V, (st || this).options.ghostClass, !1), k(V, this.options.chosenClass, !1), q({
+      }), $ = Z && Z.parentNode, rt = j(Z), lt = j(Z, n.draggable), jt.eventCanceled || (_t = Ct = Dt = !1, clearInterval(this._loopId), clearTimeout(this._dragStartTimer), zt(this.cloneId), zt(this._dragStartId), this.nativeDraggable && (p(document, "drop", this), p(e, "dragstart", this._onDragStart)), this._offMoveEvents(), this._offUpEvents(), u && R(document.body, "user-select", ""), R(Z, "transform", ""), t && (mt && (t.cancelable && t.preventDefault(), n.dropBubble || t.stopPropagation()), Q && Q.parentNode && Q.parentNode.removeChild(Q), (J === $ || ct && "clone" !== ct.lastPutMode) && nt && nt.parentNode && nt.parentNode.removeChild(nt), Z && (this.nativeDraggable && p(Z, "dragend", this), Lt(Z), Z.style["will-change"] = "", mt && !Dt && k(Z, (ct || this).options.ghostClass, !1), k(Z, this.options.chosenClass, !1), V({
         sortable: this,
         name: "unchoose",
-        toEl: Z,
+        toEl: $,
         newIndex: null,
         newDraggableIndex: null,
         originalEvent: t
-      }), Q !== Z ? (0 <= it && (q({
-        rootEl: Z,
+      }), J !== $ ? (0 <= rt && (V({
+        rootEl: $,
         name: "add",
-        toEl: Z,
-        fromEl: Q,
+        toEl: $,
+        fromEl: J,
         originalEvent: t
-      }), q({
+      }), V({
         sortable: this,
         name: "remove",
-        toEl: Z,
+        toEl: $,
         originalEvent: t
-      }), q({
-        rootEl: Z,
+      }), V({
+        rootEl: $,
         name: "sort",
-        toEl: Z,
-        fromEl: Q,
+        toEl: $,
+        fromEl: J,
         originalEvent: t
-      }), q({
+      }), V({
         sortable: this,
         name: "sort",
-        toEl: Z,
+        toEl: $,
         originalEvent: t
-      })), st && st.save()) : it !== ot && 0 <= it && (q({
+      })), ct && ct.save()) : rt !== it && 0 <= rt && (V({
         sortable: this,
         name: "update",
-        toEl: Z,
+        toEl: $,
         originalEvent: t
-      }), q({
+      }), V({
         sortable: this,
         name: "sort",
-        toEl: Z,
+        toEl: $,
         originalEvent: t
-      })), Ft.active && (null != it && -1 !== it || (it = ot, at = rt), q({
+      })), jt.active && (null != rt && -1 !== rt || (rt = it, lt = at), V({
         sortable: this,
         name: "end",
-        toEl: Z,
+        toEl: $,
         originalEvent: t
       }), this.save())))), this._nulling();
     },
     _nulling: function _nulling() {
-      G("nulling", this), Q = V = Z = $ = J = et = tt = nt = ct = ut = gt = it = at = ot = rt = mt = vt = st = lt = Ft.dragged = Ft.ghost = Ft.clone = Ft.active = null, xt.forEach(function (t) {
+      U("nulling", this), J = Z = $ = Q = tt = nt = et = ot = ut = dt = mt = rt = lt = it = at = vt = bt = ct = st = jt.dragged = jt.ghost = jt.clone = jt.active = null, Ot.forEach(function (t) {
         t.checked = !0;
-      }), xt.length = dt = ht = 0;
+      }), Ot.length = ht = pt = 0;
     },
     handleEvent: function handleEvent(t) {
       switch (t.type) {
@@ -1015,7 +988,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           break;
         case "dragenter":
         case "dragover":
-          V && (this._onDragOver(t), function (t) {
+          Z && (this._onDragOver(t), function (t) {
             t.dataTransfer && (t.dataTransfer.dropEffect = "move");
             t.cancelable && t.preventDefault();
           }(t));
@@ -1025,17 +998,13 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       }
     },
     toArray: function toArray() {
-      for (var t, e = [], n = this.el.children, o = 0, i = n.length, r = this.options; o < i; o++) {
-        P(t = n[o], r.draggable, this.el, !1) && e.push(t.getAttribute(r.dataIdAttr) || function (t) {
-          var e = t.tagName + t.className + t.src + t.href + t.textContent,
-            n = e.length,
-            o = 0;
-          for (; n--;) {
-            o += e.charCodeAt(n);
-          }
-          return o.toString(36);
-        }(t));
-      }
+      for (var t, e = [], n = this.el.children, o = 0, i = n.length, r = this.options; o < i; o++) P(t = n[o], r.draggable, this.el, !1) && e.push(t.getAttribute(r.dataIdAttr) || function (t) {
+        var e = t.tagName + t.className + t.src + t.href + t.textContent,
+          n = e.length,
+          o = 0;
+        for (; n--;) o += e.charCodeAt(n);
+        return o.toString(36);
+      }(t));
       return e;
     },
     sort: function sort(t, e) {
@@ -1058,78 +1027,75 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     option: function option(t, e) {
       var n = this.options;
       if (void 0 === e) return n[t];
-      var o = W.modifyOption(this, t, e);
-      n[t] = void 0 !== o ? o : e, "group" === t && kt(n);
+      var o = z.modifyOption(this, t, e);
+      n[t] = void 0 !== o ? o : e, "group" === t && Rt(n);
     },
     destroy: function destroy() {
-      G("destroy", this);
+      U("destroy", this);
       var t = this.el;
-      t[K] = null, f(t, "mousedown", this._onTapStart), f(t, "touchstart", this._onTapStart), f(t, "pointerdown", this._onTapStart), this.nativeDraggable && (f(t, "dragover", this), f(t, "dragenter", this)), Array.prototype.forEach.call(t.querySelectorAll("[draggable]"), function (t) {
+      t[K] = null, p(t, "mousedown", this._onTapStart), p(t, "touchstart", this._onTapStart), p(t, "pointerdown", this._onTapStart), this.nativeDraggable && (p(t, "dragover", this), p(t, "dragenter", this)), Array.prototype.forEach.call(t.querySelectorAll("[draggable]"), function (t) {
         t.removeAttribute("draggable");
-      }), this._onDrop(), this._disableDelayedDragEvents(), Dt.splice(Dt.indexOf(this.el), 1), this.el = t = null;
+      }), this._onDrop(), this._disableDelayedDragEvents(), St.splice(St.indexOf(this.el), 1), this.el = t = null;
     },
     _hideClone: function _hideClone() {
-      nt || (G("hideClone", this), Ft.eventCanceled || (R(et, "display", "none"), this.options.removeCloneOnHide && et.parentNode && et.parentNode.removeChild(et), nt = !0));
+      ot || (U("hideClone", this), jt.eventCanceled || (R(nt, "display", "none"), this.options.removeCloneOnHide && nt.parentNode && nt.parentNode.removeChild(nt), ot = !0));
     },
     _showClone: function _showClone(t) {
-      "clone" === t.lastPutMode ? nt && (G("showClone", this), Ft.eventCanceled || (V.parentNode != Q || this.options.group.revertClone ? J ? Q.insertBefore(et, J) : Q.appendChild(et) : Q.insertBefore(et, V), this.options.group.revertClone && this.animate(V, et), R(et, "display", ""), nt = !1)) : this._hideClone();
+      "clone" === t.lastPutMode ? ot && (U("showClone", this), jt.eventCanceled || (Z.parentNode != J || this.options.group.revertClone ? tt ? J.insertBefore(nt, tt) : J.appendChild(nt) : J.insertBefore(nt, Z), this.options.group.revertClone && this.animate(Z, nt), R(nt, "display", ""), ot = !1)) : this._hideClone();
     }
-  }, Ot && h(document, "touchmove", function (t) {
-    (Ft.active || wt) && t.cancelable && t.preventDefault();
-  }), Ft.utils = {
+  }, Mt && h(document, "touchmove", function (t) {
+    (jt.active || Dt) && t.cancelable && t.preventDefault();
+  }), jt.utils = {
     on: h,
-    off: f,
+    off: p,
     css: R,
-    find: b,
+    find: D,
     is: function is(t, e) {
       return !!P(t, e, t, !1);
     },
     extend: function extend(t, e) {
-      if (t && e) for (var n in e) {
-        e.hasOwnProperty(n) && (t[n] = e[n]);
-      }
+      if (t && e) for (var n in e) e.hasOwnProperty(n) && (t[n] = e[n]);
       return t;
     },
-    throttle: S,
+    throttle: _,
     closest: P,
     toggleClass: k,
-    clone: _,
+    clone: C,
     index: j,
-    nextTick: Kt,
-    cancelNextTick: Wt,
-    detectDirection: Pt,
-    getChild: B
-  }, Ft.get = function (t) {
+    nextTick: Wt,
+    cancelNextTick: zt,
+    detectDirection: kt,
+    getChild: B,
+    expando: K
+  }, jt.get = function (t) {
     return t[K];
-  }, Ft.mount = function () {
-    for (var t = arguments.length, e = new Array(t), n = 0; n < t; n++) {
-      e[n] = arguments[n];
-    }
+  }, jt.mount = function () {
+    for (var t = arguments.length, e = new Array(t), n = 0; n < t; n++) e[n] = arguments[n];
     (e = e[0].constructor === Array ? e[0] : e).forEach(function (t) {
       if (!t.prototype || !t.prototype.constructor) throw "Sortable: Mounted plugin must be a constructor function, not ".concat({}.toString.call(t));
-      t.utils && (Ft.utils = I(I({}, Ft.utils), t.utils)), W.mount(t);
+      t.utils && (jt.utils = I(I({}, jt.utils), t.utils)), z.mount(t);
     });
-  }, Ft.create = function (t, e) {
-    return new Ft(t, e);
+  }, jt.create = function (t, e) {
+    return new jt(t, e);
   };
-  var zt,
-    Gt,
+  var Gt,
     Ut,
     qt,
     Vt,
     Zt,
-    $t = [],
-    Qt = !(Ft.version = "1.15.2");
-  function Jt() {
-    $t.forEach(function (t) {
-      clearInterval(t.pid);
-    }), $t = [];
-  }
+    $t,
+    Qt = [],
+    Jt = !(jt.version = "1.15.6");
   function te() {
-    clearInterval(Zt);
+    Qt.forEach(function (t) {
+      clearInterval(t.pid);
+    }), Qt = [];
   }
-  var ee,
-    ne = S(function (n, t, e, o) {
+  function ee() {
+    clearInterval($t);
+  }
+  var ne,
+    oe = _(function (n, t, e, o) {
       if (t.scroll) {
         var i,
           r = (n.touches ? n.touches[0] : n).clientX,
@@ -1138,44 +1104,42 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           s = t.scrollSpeed,
           c = O(),
           u = !1;
-        Gt !== e && (Gt = e, Jt(), zt = t.scroll, i = t.scrollFn, !0 === zt && (zt = M(e, !0)));
+        Ut !== e && (Ut = e, te(), Gt = t.scroll, i = t.scrollFn, !0 === Gt && (Gt = M(e, !0)));
         var d = 0,
-          h = zt;
+          h = Gt;
         do {
-          var f = h,
-            p = X(f),
-            g = p.top,
-            m = p.bottom,
-            v = p.left,
-            b = p.right,
-            y = p.width,
-            w = p.height,
-            E = void 0,
+          var p = h,
+            f = X(p),
+            g = f.top,
+            m = f.bottom,
+            v = f.left,
+            b = f.right,
+            y = f.width,
+            w = f.height,
             D = void 0,
-            S = f.scrollWidth,
-            _ = f.scrollHeight,
-            C = R(f),
-            T = f.scrollLeft,
-            p = f.scrollTop,
-            D = f === c ? (E = y < S && ("auto" === C.overflowX || "scroll" === C.overflowX || "visible" === C.overflowX), w < _ && ("auto" === C.overflowY || "scroll" === C.overflowY || "visible" === C.overflowY)) : (E = y < S && ("auto" === C.overflowX || "scroll" === C.overflowX), w < _ && ("auto" === C.overflowY || "scroll" === C.overflowY)),
-            T = E && (Math.abs(b - r) <= l && T + y < S) - (Math.abs(v - r) <= l && !!T),
-            p = D && (Math.abs(m - a) <= l && p + w < _) - (Math.abs(g - a) <= l && !!p);
-          if (!$t[d]) for (var x = 0; x <= d; x++) {
-            $t[x] || ($t[x] = {});
-          }
-          $t[d].vx == T && $t[d].vy == p && $t[d].el === f || ($t[d].el = f, $t[d].vx = T, $t[d].vy = p, clearInterval($t[d].pid), 0 == T && 0 == p || (u = !0, $t[d].pid = setInterval(function () {
-            o && 0 === this.layer && Ft.active._onTouchMove(Vt);
-            var t = $t[this.layer].vy ? $t[this.layer].vy * s : 0,
-              e = $t[this.layer].vx ? $t[this.layer].vx * s : 0;
-            "function" == typeof i && "continue" !== i.call(Ft.dragged.parentNode[K], e, t, n, Vt, $t[this.layer].el) || H($t[this.layer].el, e, t);
+            E = void 0,
+            S = p.scrollWidth,
+            _ = p.scrollHeight,
+            C = R(p),
+            T = p.scrollLeft,
+            f = p.scrollTop,
+            E = p === c ? (D = y < S && ("auto" === C.overflowX || "scroll" === C.overflowX || "visible" === C.overflowX), w < _ && ("auto" === C.overflowY || "scroll" === C.overflowY || "visible" === C.overflowY)) : (D = y < S && ("auto" === C.overflowX || "scroll" === C.overflowX), w < _ && ("auto" === C.overflowY || "scroll" === C.overflowY)),
+            T = D && (Math.abs(b - r) <= l && T + y < S) - (Math.abs(v - r) <= l && !!T),
+            f = E && (Math.abs(m - a) <= l && f + w < _) - (Math.abs(g - a) <= l && !!f);
+          if (!Qt[d]) for (var x = 0; x <= d; x++) Qt[x] || (Qt[x] = {});
+          Qt[d].vx == T && Qt[d].vy == f && Qt[d].el === p || (Qt[d].el = p, Qt[d].vx = T, Qt[d].vy = f, clearInterval(Qt[d].pid), 0 == T && 0 == f || (u = !0, Qt[d].pid = setInterval(function () {
+            o && 0 === this.layer && jt.active._onTouchMove(Zt);
+            var t = Qt[this.layer].vy ? Qt[this.layer].vy * s : 0,
+              e = Qt[this.layer].vx ? Qt[this.layer].vx * s : 0;
+            "function" == typeof i && "continue" !== i.call(jt.dragged.parentNode[K], e, t, n, Zt, Qt[this.layer].el) || H(Qt[this.layer].el, e, t);
           }.bind({
             layer: d
           }), 24))), d++;
         } while (t.bubbleScroll && h !== c && (h = M(h, !1)));
-        Qt = u;
+        Jt = u;
       }
     }, 30),
-    c = function c(t) {
+    n = function n(t) {
       var e = t.originalEvent,
         n = t.putSortable,
         o = t.dragEl,
@@ -1188,9 +1152,9 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         putSortable: n
       })));
     };
-  function oe() {}
   function ie() {}
-  oe.prototype = {
+  function re() {}
+  ie.prototype = {
     startIndex: null,
     dragStart: function dragStart(t) {
       t = t.oldDraggableIndex;
@@ -1203,41 +1167,41 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       t = B(this.sortable.el, this.startIndex, this.options);
       t ? this.sortable.el.insertBefore(e, t) : this.sortable.el.appendChild(e), this.sortable.animateAll(), n && n.animateAll();
     },
-    drop: c
-  }, a(oe, {
+    drop: n
+  }, a(ie, {
     pluginName: "revertOnSpill"
-  }), ie.prototype = {
+  }), re.prototype = {
     onSpill: function onSpill(t) {
       var e = t.dragEl,
         t = t.putSortable || this.sortable;
       t.captureAnimationState(), e.parentNode && e.parentNode.removeChild(e), t.animateAll();
     },
-    drop: c
-  }, a(ie, {
+    drop: n
+  }, a(re, {
     pluginName: "removeOnSpill"
   });
-  var re,
-    ae,
+  var ae,
     le,
     se,
     ce,
-    ue = [],
+    ue,
     de = [],
-    he = !1,
+    he = [],
+    pe = !1,
     fe = !1,
-    pe = !1;
-  function ge(n, o) {
-    de.forEach(function (t, e) {
+    ge = !1;
+  function me(n, o) {
+    he.forEach(function (t, e) {
       e = o.children[t.sortableIndex + (n ? Number(e) : 0)];
       e ? o.insertBefore(t, e) : o.appendChild(t);
     });
   }
-  function me() {
-    ue.forEach(function (t) {
-      t !== le && t.parentNode && t.parentNode.removeChild(t);
+  function ve() {
+    de.forEach(function (t) {
+      t !== se && t.parentNode && t.parentNode.removeChild(t);
     });
   }
-  return Ft.mount(new function () {
+  return jt.mount(new function () {
     function t() {
       for (var t in this.defaults = {
         scroll: !0,
@@ -1245,9 +1209,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         scrollSensitivity: 30,
         scrollSpeed: 10,
         bubbleScroll: !0
-      }, this) {
-        "_" === t.charAt(0) && "function" == typeof this[t] && (this[t] = this[t].bind(this));
-      }
+      }, this) "_" === t.charAt(0) && "function" == typeof this[t] && (this[t] = this[t].bind(this));
     }
     return t.prototype = {
       dragStarted: function dragStarted(t) {
@@ -1259,10 +1221,10 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         this.options.dragOverBubble || t.rootEl || this._handleAutoScroll(t);
       },
       drop: function drop() {
-        this.sortable.nativeDraggable ? f(document, "dragover", this._handleAutoScroll) : (f(document, "pointermove", this._handleFallbackAutoScroll), f(document, "touchmove", this._handleFallbackAutoScroll), f(document, "mousemove", this._handleFallbackAutoScroll)), te(), Jt(), clearTimeout(g), g = void 0;
+        this.sortable.nativeDraggable ? p(document, "dragover", this._handleAutoScroll) : (p(document, "pointermove", this._handleFallbackAutoScroll), p(document, "touchmove", this._handleFallbackAutoScroll), p(document, "mousemove", this._handleFallbackAutoScroll)), ee(), te(), clearTimeout(m), m = void 0;
       },
       nulling: function nulling() {
-        Vt = Gt = zt = Qt = Zt = Ut = qt = null, $t.length = 0;
+        Zt = Ut = Gt = Jt = $t = qt = Vt = null, Qt.length = 0;
       },
       _handleFallbackAutoScroll: function _handleFallbackAutoScroll(t) {
         this._handleAutoScroll(t, !0);
@@ -1273,16 +1235,16 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           r = (e.touches ? e.touches[0] : e).clientX,
           a = (e.touches ? e.touches[0] : e).clientY,
           t = document.elementFromPoint(r, a);
-        Vt = e, n || this.options.forceAutoScrollFallback || w || y || u ? (ne(e, this.options, t, n), o = M(t, !0), !Qt || Zt && r === Ut && a === qt || (Zt && te(), Zt = setInterval(function () {
+        Zt = e, n || this.options.forceAutoScrollFallback || w || y || u ? (oe(e, this.options, t, n), o = M(t, !0), !Jt || $t && r === qt && a === Vt || ($t && ee(), $t = setInterval(function () {
           var t = M(document.elementFromPoint(r, a), !0);
-          t !== o && (o = t, Jt()), ne(e, i.options, t, n);
-        }, 10), Ut = r, qt = a)) : this.options.bubbleScroll && M(t, !0) !== O() ? ne(e, this.options, M(t, !1), !1) : Jt();
+          t !== o && (o = t, te()), oe(e, i.options, t, n);
+        }, 10), qt = r, Vt = a)) : this.options.bubbleScroll && M(t, !0) !== O() ? oe(e, this.options, M(t, !1), !1) : te();
       }
     }, a(t, {
       pluginName: "scroll",
       initializeByDefault: !0
     });
-  }()), Ft.mount(ie, oe), Ft.mount(new function () {
+  }()), jt.mount(re, ie), jt.mount(new function () {
     function t() {
       this.defaults = {
         swapClass: "sortable-swap-highlight"
@@ -1291,7 +1253,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     return t.prototype = {
       dragStart: function dragStart(t) {
         t = t.dragEl;
-        ee = t;
+        ne = t;
       },
       dragOverValid: function dragOverValid(t) {
         var e = t.completed,
@@ -1300,7 +1262,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           i = t.activeSortable,
           r = t.changed,
           a = t.cancel;
-        i.options.swap && (t = this.sortable.el, i = this.options, n && n !== t && (t = ee, ee = !1 !== o(n) ? (k(n, i.swapClass, !0), n) : null, t && t !== ee && k(t, i.swapClass, !1)), r(), e(!0), a());
+        i.options.swap && (t = this.sortable.el, i = this.options, n && n !== t && (t = ne, ne = !1 !== o(n) ? (k(n, i.swapClass, !0), n) : null, t && t !== ne && k(t, i.swapClass, !1)), r(), e(!0), a());
       },
       drop: function drop(t) {
         var e,
@@ -1310,31 +1272,29 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           r = t.dragEl,
           a = i || this.sortable,
           l = this.options;
-        ee && k(ee, l.swapClass, !1), ee && (l.swap || i && i.options.swap) && r !== ee && (a.captureAnimationState(), a !== o && o.captureAnimationState(), n = ee, t = (e = r).parentNode, l = n.parentNode, t && l && !t.isEqualNode(n) && !l.isEqualNode(e) && (i = j(e), r = j(n), t.isEqualNode(l) && i < r && r++, t.insertBefore(n, t.children[i]), l.insertBefore(e, l.children[r])), a.animateAll(), a !== o && o.animateAll());
+        ne && k(ne, l.swapClass, !1), ne && (l.swap || i && i.options.swap) && r !== ne && (a.captureAnimationState(), a !== o && o.captureAnimationState(), n = ne, t = (e = r).parentNode, l = n.parentNode, t && l && !t.isEqualNode(n) && !l.isEqualNode(e) && (i = j(e), r = j(n), t.isEqualNode(l) && i < r && r++, t.insertBefore(n, t.children[i]), l.insertBefore(e, l.children[r])), a.animateAll(), a !== o && o.animateAll());
       },
       nulling: function nulling() {
-        ee = null;
+        ne = null;
       }
     }, a(t, {
       pluginName: "swap",
       eventProperties: function eventProperties() {
         return {
-          swapItem: ee
+          swapItem: ne
         };
       }
     });
-  }()), Ft.mount(new function () {
+  }()), jt.mount(new function () {
     function t(o) {
-      for (var t in this) {
-        "_" === t.charAt(0) && "function" == typeof this[t] && (this[t] = this[t].bind(this));
-      }
+      for (var t in this) "_" === t.charAt(0) && "function" == typeof this[t] && (this[t] = this[t].bind(this));
       o.options.avoidImplicitDeselect || (o.options.supportPointer ? h(document, "pointerup", this._deselectMultiDrag) : (h(document, "mouseup", this._deselectMultiDrag), h(document, "touchend", this._deselectMultiDrag))), h(document, "keydown", this._checkKeyDown), h(document, "keyup", this._checkKeyUp), this.defaults = {
         selectedClass: "sortable-selected",
         multiDragKey: null,
         avoidImplicitDeselect: !1,
         setData: function setData(t, e) {
           var n = "";
-          ue.length && ae === o ? ue.forEach(function (t, e) {
+          de.length && le === o ? de.forEach(function (t, e) {
             n += (e ? ", " : "") + t.textContent;
           }) : n = e.textContent, t.setData("Text", n);
         }
@@ -1345,18 +1305,16 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       isMultiDrag: !1,
       delayStartGlobal: function delayStartGlobal(t) {
         t = t.dragEl;
-        le = t;
+        se = t;
       },
       delayEnded: function delayEnded() {
-        this.isMultiDrag = ~ue.indexOf(le);
+        this.isMultiDrag = ~de.indexOf(se);
       },
       setupClone: function setupClone(t) {
         var e = t.sortable,
           t = t.cancel;
         if (this.isMultiDrag) {
-          for (var n = 0; n < ue.length; n++) {
-            de.push(_(ue[n])), de[n].sortableIndex = ue[n].sortableIndex, de[n].draggable = !1, de[n].style["will-change"] = "", k(de[n], this.options.selectedClass, !1), ue[n] === le && k(de[n], this.options.chosenClass, !1);
-          }
+          for (var n = 0; n < de.length; n++) he.push(C(de[n])), he[n].sortableIndex = de[n].sortableIndex, he[n].draggable = !1, he[n].style["will-change"] = "", k(he[n], this.options.selectedClass, !1), de[n] === se && k(he[n], this.options.chosenClass, !1);
           e._hideClone(), t();
         }
       },
@@ -1365,51 +1323,51 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           n = t.rootEl,
           o = t.dispatchSortableEvent,
           t = t.cancel;
-        this.isMultiDrag && (this.options.removeCloneOnHide || ue.length && ae === e && (ge(!0, n), o("clone"), t()));
+        this.isMultiDrag && (this.options.removeCloneOnHide || de.length && le === e && (me(!0, n), o("clone"), t()));
       },
       showClone: function showClone(t) {
         var e = t.cloneNowShown,
           n = t.rootEl,
           t = t.cancel;
-        this.isMultiDrag && (ge(!1, n), de.forEach(function (t) {
+        this.isMultiDrag && (me(!1, n), he.forEach(function (t) {
           R(t, "display", "");
-        }), e(), ce = !1, t());
+        }), e(), ue = !1, t());
       },
       hideClone: function hideClone(t) {
         var e = this,
           n = (t.sortable, t.cloneNowHidden),
           t = t.cancel;
-        this.isMultiDrag && (de.forEach(function (t) {
+        this.isMultiDrag && (he.forEach(function (t) {
           R(t, "display", "none"), e.options.removeCloneOnHide && t.parentNode && t.parentNode.removeChild(t);
-        }), n(), ce = !0, t());
+        }), n(), ue = !0, t());
       },
       dragStartGlobal: function dragStartGlobal(t) {
         t.sortable;
-        !this.isMultiDrag && ae && ae.multiDrag._deselectMultiDrag(), ue.forEach(function (t) {
+        !this.isMultiDrag && le && le.multiDrag._deselectMultiDrag(), de.forEach(function (t) {
           t.sortableIndex = j(t);
-        }), ue = ue.sort(function (t, e) {
+        }), de = de.sort(function (t, e) {
           return t.sortableIndex - e.sortableIndex;
-        }), pe = !0;
+        }), ge = !0;
       },
       dragStarted: function dragStarted(t) {
         var e,
           n = this,
           t = t.sortable;
-        this.isMultiDrag && (this.options.sort && (t.captureAnimationState(), this.options.animation && (ue.forEach(function (t) {
-          t !== le && R(t, "position", "absolute");
-        }), e = X(le, !1, !0, !0), ue.forEach(function (t) {
-          t !== le && C(t, e);
-        }), he = fe = !0)), t.animateAll(function () {
-          he = fe = !1, n.options.animation && ue.forEach(function (t) {
-            T(t);
-          }), n.options.sort && me();
+        this.isMultiDrag && (this.options.sort && (t.captureAnimationState(), this.options.animation && (de.forEach(function (t) {
+          t !== se && R(t, "position", "absolute");
+        }), e = X(se, !1, !0, !0), de.forEach(function (t) {
+          t !== se && T(t, e);
+        }), pe = fe = !0)), t.animateAll(function () {
+          pe = fe = !1, n.options.animation && de.forEach(function (t) {
+            x(t);
+          }), n.options.sort && ve();
         }));
       },
       dragOver: function dragOver(t) {
         var e = t.target,
           n = t.completed,
           t = t.cancel;
-        fe && ~ue.indexOf(e) && (n(!1), t());
+        fe && ~de.indexOf(e) && (n(!1), t());
       },
       revert: function revert(t) {
         var n,
@@ -1418,12 +1376,12 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           i = t.rootEl,
           r = t.sortable,
           a = t.dragRect;
-        1 < ue.length && (ue.forEach(function (t) {
+        1 < de.length && (de.forEach(function (t) {
           r.addAnimationState({
             target: t,
             rect: fe ? X(t) : a
-          }), T(t), t.fromRect = a, e.removeAnimationState(t);
-        }), fe = !1, n = !this.options.removeCloneOnHide, o = i, ue.forEach(function (t, e) {
+          }), x(t), t.fromRect = a, e.removeAnimationState(t);
+        }), fe = !1, n = !this.options.removeCloneOnHide, o = i, de.forEach(function (t, e) {
           e = o.children[t.sortableIndex + (n ? Number(e) : 0)];
           e ? o.insertBefore(t, e) : o.appendChild(t);
         }));
@@ -1437,96 +1395,90 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           a = t.parentEl,
           l = t.putSortable,
           t = this.options;
-        i && (o && r._hideClone(), he = !1, t.animation && 1 < ue.length && (fe || !o && !r.options.sort && !l) && (e = X(le, !1, !0, !0), ue.forEach(function (t) {
-          t !== le && (C(t, e), a.appendChild(t));
-        }), fe = !0), o || (fe || me(), 1 < ue.length ? (o = ce, r._showClone(n), r.options.animation && !ce && o && de.forEach(function (t) {
+        i && (o && r._hideClone(), pe = !1, t.animation && 1 < de.length && (fe || !o && !r.options.sort && !l) && (e = X(se, !1, !0, !0), de.forEach(function (t) {
+          t !== se && (T(t, e), a.appendChild(t));
+        }), fe = !0), o || (fe || ve(), 1 < de.length ? (o = ue, r._showClone(n), r.options.animation && !ue && o && he.forEach(function (t) {
           r.addAnimationState({
             target: t,
-            rect: se
-          }), t.fromRect = se, t.thisAnimationDuration = null;
+            rect: ce
+          }), t.fromRect = ce, t.thisAnimationDuration = null;
         })) : r._showClone(n)));
       },
       dragOverAnimationCapture: function dragOverAnimationCapture(t) {
         var e = t.dragRect,
           n = t.isOwner,
           t = t.activeSortable;
-        ue.forEach(function (t) {
+        de.forEach(function (t) {
           t.thisAnimationDuration = null;
-        }), t.options.animation && !n && t.multiDrag.isMultiDrag && (se = a({}, e), e = v(le, !0), se.top -= e.f, se.left -= e.e);
+        }), t.options.animation && !n && t.multiDrag.isMultiDrag && (ce = a({}, e), e = b(se, !0), ce.top -= e.f, ce.left -= e.e);
       },
       dragOverAnimationComplete: function dragOverAnimationComplete() {
-        fe && (fe = !1, me());
+        fe && (fe = !1, ve());
       },
       drop: function drop(t) {
-        var e = t.originalEvent,
-          n = t.rootEl,
-          o = t.parentEl,
-          i = t.sortable,
-          r = t.dispatchSortableEvent,
-          a = t.oldIndex,
-          l = t.putSortable,
-          s = l || this.sortable;
-        if (e) {
-          var c,
-            u,
-            d,
-            h = this.options,
-            f = o.children;
-          if (!pe) if (h.multiDragKey && !this.multiDragKeyDown && this._deselectMultiDrag(), k(le, h.selectedClass, !~ue.indexOf(le)), ~ue.indexOf(le)) ue.splice(ue.indexOf(le), 1), re = null, z({
-            sortable: i,
-            rootEl: n,
-            name: "deselect",
-            targetEl: le,
-            originalEvent: e
-          });else {
-            if (ue.push(le), z({
-              sortable: i,
-              rootEl: n,
-              name: "select",
-              targetEl: le,
-              originalEvent: e
-            }), e.shiftKey && re && i.el.contains(re)) {
-              var p = j(re),
-                t = j(le);
-              if (~p && ~t && p !== t) for (var g, m = p < t ? (g = p, t) : (g = t, p + 1); g < m; g++) {
-                ~ue.indexOf(f[g]) || (k(f[g], h.selectedClass, !0), ue.push(f[g]), z({
-                  sortable: i,
-                  rootEl: n,
-                  name: "select",
-                  targetEl: f[g],
-                  originalEvent: e
-                }));
-              }
-            } else re = le;
-            ae = s;
-          }
-          pe && this.isMultiDrag && (fe = !1, (o[K].options.sort || o !== n) && 1 < ue.length && (c = X(le), u = j(le, ":not(." + this.options.selectedClass + ")"), !he && h.animation && (le.thisAnimationDuration = null), s.captureAnimationState(), he || (h.animation && (le.fromRect = c, ue.forEach(function (t) {
-            var e;
-            t.thisAnimationDuration = null, t !== le && (e = fe ? X(t) : c, t.fromRect = e, s.addAnimationState({
-              target: t,
-              rect: e
-            }));
-          })), me(), ue.forEach(function (t) {
-            f[u] ? o.insertBefore(t, f[u]) : o.appendChild(t), u++;
-          }), a === j(le) && (d = !1, ue.forEach(function (t) {
-            t.sortableIndex !== j(t) && (d = !0);
-          }), d && (r("update"), r("sort")))), ue.forEach(function (t) {
-            T(t);
-          }), s.animateAll()), ae = s), (n === o || l && "clone" !== l.lastPutMode) && de.forEach(function (t) {
-            t.parentNode && t.parentNode.removeChild(t);
-          });
-        }
+        var o,
+          i,
+          r,
+          a,
+          n,
+          e,
+          l,
+          s = t.originalEvent,
+          c = t.rootEl,
+          u = t.parentEl,
+          d = t.sortable,
+          h = t.dispatchSortableEvent,
+          p = t.oldIndex,
+          t = t.putSortable,
+          f = t || this.sortable;
+        s && (o = this.options, i = u.children, ge || (o.multiDragKey && !this.multiDragKeyDown && this._deselectMultiDrag(), k(se, o.selectedClass, !~de.indexOf(se)), ~de.indexOf(se) ? (de.splice(de.indexOf(se), 1), ae = null, G({
+          sortable: d,
+          rootEl: c,
+          name: "deselect",
+          targetEl: se,
+          originalEvent: s
+        })) : (de.push(se), G({
+          sortable: d,
+          rootEl: c,
+          name: "select",
+          targetEl: se,
+          originalEvent: s
+        }), s.shiftKey && ae && d.el.contains(ae) ? (r = j(ae), a = j(se), ~r && ~a && r !== a && function () {
+          for (var e, t = r < a ? (e = r, a) : (e = a, r + 1), n = o.filter; e < t; e++) ~de.indexOf(i[e]) || P(i[e], o.draggable, u, !1) && (n && ("function" == typeof n ? n.call(d, s, i[e], d) : n.split(",").some(function (t) {
+            return P(i[e], t.trim(), u, !1);
+          })) || (k(i[e], o.selectedClass, !0), de.push(i[e]), G({
+            sortable: d,
+            rootEl: c,
+            name: "select",
+            targetEl: i[e],
+            originalEvent: s
+          })));
+        }()) : ae = se, le = f)), ge && this.isMultiDrag && (fe = !1, (u[K].options.sort || u !== c) && 1 < de.length && (n = X(se), e = j(se, ":not(." + this.options.selectedClass + ")"), !pe && o.animation && (se.thisAnimationDuration = null), f.captureAnimationState(), pe || (o.animation && (se.fromRect = n, de.forEach(function (t) {
+          var e;
+          t.thisAnimationDuration = null, t !== se && (e = fe ? X(t) : n, t.fromRect = e, f.addAnimationState({
+            target: t,
+            rect: e
+          }));
+        })), ve(), de.forEach(function (t) {
+          i[e] ? u.insertBefore(t, i[e]) : u.appendChild(t), e++;
+        }), p === j(se) && (l = !1, de.forEach(function (t) {
+          t.sortableIndex !== j(t) && (l = !0);
+        }), l && (h("update"), h("sort")))), de.forEach(function (t) {
+          x(t);
+        }), f.animateAll()), le = f), (c === u || t && "clone" !== t.lastPutMode) && he.forEach(function (t) {
+          t.parentNode && t.parentNode.removeChild(t);
+        }));
       },
       nullingGlobal: function nullingGlobal() {
-        this.isMultiDrag = pe = !1, de.length = 0;
+        this.isMultiDrag = ge = !1, he.length = 0;
       },
       destroyGlobal: function destroyGlobal() {
-        this._deselectMultiDrag(), f(document, "pointerup", this._deselectMultiDrag), f(document, "mouseup", this._deselectMultiDrag), f(document, "touchend", this._deselectMultiDrag), f(document, "keydown", this._checkKeyDown), f(document, "keyup", this._checkKeyUp);
+        this._deselectMultiDrag(), p(document, "pointerup", this._deselectMultiDrag), p(document, "mouseup", this._deselectMultiDrag), p(document, "touchend", this._deselectMultiDrag), p(document, "keydown", this._checkKeyDown), p(document, "keyup", this._checkKeyUp);
       },
       _deselectMultiDrag: function _deselectMultiDrag(t) {
-        if (!(void 0 !== pe && pe || ae !== this.sortable || t && P(t.target, this.options.draggable, this.sortable.el, !1) || t && 0 !== t.button)) for (; ue.length;) {
-          var e = ue[0];
-          k(e, this.options.selectedClass, !1), ue.shift(), z({
+        if (!(void 0 !== ge && ge || le !== this.sortable || t && P(t.target, this.options.draggable, this.sortable.el, !1) || t && 0 !== t.button)) for (; de.length;) {
+          var e = de[0];
+          k(e, this.options.selectedClass, !1), de.shift(), G({
             sortable: this.sortable,
             rootEl: this.sortable.el,
             name: "deselect",
@@ -1546,30 +1498,30 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       utils: {
         select: function select(t) {
           var e = t.parentNode[K];
-          e && e.options.multiDrag && !~ue.indexOf(t) && (ae && ae !== e && (ae.multiDrag._deselectMultiDrag(), ae = e), k(t, e.options.selectedClass, !0), ue.push(t));
+          e && e.options.multiDrag && !~de.indexOf(t) && (le && le !== e && (le.multiDrag._deselectMultiDrag(), le = e), k(t, e.options.selectedClass, !0), de.push(t));
         },
         deselect: function deselect(t) {
           var e = t.parentNode[K],
-            n = ue.indexOf(t);
-          e && e.options.multiDrag && ~n && (k(t, e.options.selectedClass, !1), ue.splice(n, 1));
+            n = de.indexOf(t);
+          e && e.options.multiDrag && ~n && (k(t, e.options.selectedClass, !1), de.splice(n, 1));
         }
       },
       eventProperties: function eventProperties() {
         var n = this,
           o = [],
           i = [];
-        return ue.forEach(function (t) {
+        return de.forEach(function (t) {
           var e;
           o.push({
             multiDragElement: t,
             index: t.sortableIndex
-          }), e = fe && t !== le ? -1 : fe ? j(t, ":not(." + n.options.selectedClass + ")") : j(t), i.push({
+          }), e = fe && t !== se ? -1 : fe ? j(t, ":not(." + n.options.selectedClass + ")") : j(t), i.push({
             multiDragElement: t,
             index: e
           });
         }), {
-          items: r(ue),
-          clones: [].concat(de),
+          items: r(de),
+          clones: [].concat(he),
           oldIndicies: o,
           newIndicies: i
         };
@@ -1580,7 +1532,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         }
       }
     });
-  }()), Ft;
+  }()), jt;
 });
 /*! jQuery UI - v1.13.2 - 2023-02-04
 * http://jqueryui.com
@@ -1601,9 +1553,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     r = Array.prototype.hasOwnProperty,
     h = Array.prototype.slice;
   w.cleanData = (o = w.cleanData, function (t) {
-    for (var e, i, s = 0; null != (i = t[s]); s++) {
-      (e = w._data(i, "events")) && e.remove && w(i).triggerHandler("remove");
-    }
+    for (var e, i, s = 0; null != (i = t[s]); s++) (e = w._data(i, "events")) && e.remove && w(i).triggerHandler("remove");
     o(t);
   }), w.widget = function (t, i, e) {
     var s,
@@ -1646,11 +1596,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       w.widget(i.namespace + "." + i.widgetName, o, e._proto);
     }), delete s._childConstructors) : i._childConstructors.push(o), w.widget.bridge(t, o), o;
   }, w.widget.extend = function (t) {
-    for (var e, i, s = h.call(arguments, 1), o = 0, n = s.length; o < n; o++) {
-      for (e in s[o]) {
-        i = s[o][e], r.call(s[o], e) && void 0 !== i && (w.isPlainObject(i) ? t[e] = w.isPlainObject(t[e]) ? w.widget.extend({}, t[e], i) : w.widget.extend({}, i) : t[e] = i);
-      }
-    }
+    for (var e, i, s = h.call(arguments, 1), o = 0, n = s.length; o < n; o++) for (e in s[o]) i = s[o][e], r.call(s[o], e) && void 0 !== i && (w.isPlainObject(i) ? t[e] = w.isPlainObject(t[e]) ? w.widget.extend({}, t[e], i) : w.widget.extend({}, i) : t[e] = i);
     return t;
   }, w.widget.bridge = function (n, e) {
     var r = e.prototype.widgetFullName || n;
@@ -1706,9 +1652,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         n = t;
       if (0 === arguments.length) return w.widget.extend({}, this.options);
       if ("string" == typeof t) if (n = {}, t = (i = t.split(".")).shift(), i.length) {
-        for (s = n[t] = w.widget.extend({}, this.options[t]), o = 0; o < i.length - 1; o++) {
-          s[i[o]] = s[i[o]] || {}, s = s[i[o]];
-        }
+        for (s = n[t] = w.widget.extend({}, this.options[t]), o = 0; o < i.length - 1; o++) s[i[o]] = s[i[o]] || {}, s = s[i[o]];
         if (t = i.pop(), 1 === arguments.length) return void 0 === s[t] ? null : s[t];
         s[t] = e;
       } else {
@@ -1718,9 +1662,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       return this._setOptions(n), this;
     },
     _setOptions: function _setOptions(t) {
-      for (var e in t) {
-        this._setOption(e, t[e]);
-      }
+      for (var e in t) this._setOption(e, t[e]);
       return this;
     },
     _setOption: function _setOption(t, e) {
@@ -1728,14 +1670,12 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     },
     _setOptionClasses: function _setOptionClasses(t) {
       var e, i, s;
-      for (e in t) {
-        s = this.classesElementLookup[e], t[e] !== this.options.classes[e] && s && s.length && (i = w(s.get()), this._removeClass(s, e), i.addClass(this._classes({
-          element: i,
-          keys: e,
-          classes: t,
-          add: !0
-        })));
-      }
+      for (e in t) s = this.classesElementLookup[e], t[e] !== this.options.classes[e] && s && s.length && (i = w(s.get()), this._removeClass(s, e), i.addClass(this._classes({
+        element: i,
+        keys: e,
+        classes: t,
+        add: !0
+      })));
     },
     _setOptionDisabled: function _setOptionDisabled(t) {
       this._toggleClass(this.widget(), this.widgetFullName + "-disabled", null, !!t), t && (this._removeClass(this.hoverable, null, "ui-state-hover"), this._removeClass(this.focusable, null, "ui-state-focus"));
@@ -1754,20 +1694,18 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       var n = [],
         r = this;
       function t(t, e) {
-        for (var i, s = 0; s < t.length; s++) {
-          i = r.classesElementLookup[t[s]] || w(), i = o.add ? (function () {
-            var i = [];
-            o.element.each(function (t, e) {
-              w.map(r.classesElementLookup, function (t) {
-                return t;
-              }).some(function (t) {
-                return t.is(e);
-              }) || i.push(e);
-            }), r._on(w(i), {
-              remove: "_untrackClassesElement"
-            });
-          }(), w(w.uniqueSort(i.get().concat(o.element.get())))) : w(i.not(o.element).get()), r.classesElementLookup[t[s]] = i, n.push(t[s]), e && o.classes[t[s]] && n.push(o.classes[t[s]]);
-        }
+        for (var i, s = 0; s < t.length; s++) i = r.classesElementLookup[t[s]] || w(), i = o.add ? (function () {
+          var i = [];
+          o.element.each(function (t, e) {
+            w.map(r.classesElementLookup, function (t) {
+              return t;
+            }).some(function (t) {
+              return t.is(e);
+            }) || i.push(e);
+          }), r._on(w(i), {
+            remove: "_untrackClassesElement"
+          });
+        }(), w(w.uniqueSort(i.get().concat(o.element.get())))) : w(i.not(o.element).get()), r.classesElementLookup[t[s]] = i, n.push(t[s]), e && o.classes[t[s]] && n.push(o.classes[t[s]]);
       }
       return (o = w.extend({
         element: this.element,
@@ -1843,9 +1781,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       var s,
         o,
         n = this.options[t];
-      if (i = i || {}, (e = w.Event(e)).type = (t === this.widgetEventPrefix ? t : this.widgetEventPrefix + t).toLowerCase(), e.target = this.element[0], o = e.originalEvent) for (s in o) {
-        s in e || (e[s] = o[s]);
-      }
+      if (i = i || {}, (e = w.Event(e)).type = (t === this.widgetEventPrefix ? t : this.widgetEventPrefix + t).toLowerCase(), e.target = this.element[0], o = e.originalEvent) for (s in o) s in e || (e[s] = o[s]);
       return this.element.trigger(e, i), !("function" == typeof n && !1 === n.apply(this.element[0], [e].concat(i)) || e.isDefaultPrevented());
     }
   }, w.each({
@@ -2180,16 +2116,12 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     add: function add(t, e, i) {
       var s,
         o = w.ui[t].prototype;
-      for (s in i) {
-        o.plugins[s] = o.plugins[s] || [], o.plugins[s].push([e, i[s]]);
-      }
+      for (s in i) o.plugins[s] = o.plugins[s] || [], o.plugins[s].push([e, i[s]]);
     },
     call: function call(t, e, i, s) {
       var o,
         n = t.plugins[e];
-      if (n && (s || t.element[0].parentNode && 11 !== t.element[0].parentNode.nodeType)) for (o = 0; o < n.length; o++) {
-        t.options[n[o][0]] && n[o][1].apply(t.element, i);
-      }
+      if (n && (s || t.element[0].parentNode && 11 !== t.element[0].parentNode.nodeType)) for (o = 0; o < n.length; o++) t.options[n[o][0]] && n[o][1].apply(t.element, i);
     }
   }, w.ui.safeActiveElement = function (e) {
     var i;
@@ -2495,37 +2427,35 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       });
     },
     drag: function drag(t, e, i) {
-      for (var s, o, n, r, h, a, l, c, u, p = i.options, f = p.snapTolerance, d = e.offset.left, m = d + i.helperProportions.width, g = e.offset.top, v = g + i.helperProportions.height, _ = i.snapElements.length - 1; 0 <= _; _--) {
-        a = (h = i.snapElements[_].left - i.margins.left) + i.snapElements[_].width, c = (l = i.snapElements[_].top - i.margins.top) + i.snapElements[_].height, m < h - f || a + f < d || v < l - f || c + f < g || !w.contains(i.snapElements[_].item.ownerDocument, i.snapElements[_].item) ? (i.snapElements[_].snapping && i.options.snap.release && i.options.snap.release.call(i.element, t, w.extend(i._uiHash(), {
-          snapItem: i.snapElements[_].item
-        })), i.snapElements[_].snapping = !1) : ("inner" !== p.snapMode && (s = Math.abs(l - v) <= f, o = Math.abs(c - g) <= f, n = Math.abs(h - m) <= f, r = Math.abs(a - d) <= f, s && (e.position.top = i._convertPositionTo("relative", {
-          top: l - i.helperProportions.height,
-          left: 0
-        }).top), o && (e.position.top = i._convertPositionTo("relative", {
-          top: c,
-          left: 0
-        }).top), n && (e.position.left = i._convertPositionTo("relative", {
-          top: 0,
-          left: h - i.helperProportions.width
-        }).left), r && (e.position.left = i._convertPositionTo("relative", {
-          top: 0,
-          left: a
-        }).left)), u = s || o || n || r, "outer" !== p.snapMode && (s = Math.abs(l - g) <= f, o = Math.abs(c - v) <= f, n = Math.abs(h - d) <= f, r = Math.abs(a - m) <= f, s && (e.position.top = i._convertPositionTo("relative", {
-          top: l,
-          left: 0
-        }).top), o && (e.position.top = i._convertPositionTo("relative", {
-          top: c - i.helperProportions.height,
-          left: 0
-        }).top), n && (e.position.left = i._convertPositionTo("relative", {
-          top: 0,
-          left: h
-        }).left), r && (e.position.left = i._convertPositionTo("relative", {
-          top: 0,
-          left: a - i.helperProportions.width
-        }).left)), !i.snapElements[_].snapping && (s || o || n || r || u) && i.options.snap.snap && i.options.snap.snap.call(i.element, t, w.extend(i._uiHash(), {
-          snapItem: i.snapElements[_].item
-        })), i.snapElements[_].snapping = s || o || n || r || u);
-      }
+      for (var s, o, n, r, h, a, l, c, u, p = i.options, f = p.snapTolerance, d = e.offset.left, m = d + i.helperProportions.width, g = e.offset.top, v = g + i.helperProportions.height, _ = i.snapElements.length - 1; 0 <= _; _--) a = (h = i.snapElements[_].left - i.margins.left) + i.snapElements[_].width, c = (l = i.snapElements[_].top - i.margins.top) + i.snapElements[_].height, m < h - f || a + f < d || v < l - f || c + f < g || !w.contains(i.snapElements[_].item.ownerDocument, i.snapElements[_].item) ? (i.snapElements[_].snapping && i.options.snap.release && i.options.snap.release.call(i.element, t, w.extend(i._uiHash(), {
+        snapItem: i.snapElements[_].item
+      })), i.snapElements[_].snapping = !1) : ("inner" !== p.snapMode && (s = Math.abs(l - v) <= f, o = Math.abs(c - g) <= f, n = Math.abs(h - m) <= f, r = Math.abs(a - d) <= f, s && (e.position.top = i._convertPositionTo("relative", {
+        top: l - i.helperProportions.height,
+        left: 0
+      }).top), o && (e.position.top = i._convertPositionTo("relative", {
+        top: c,
+        left: 0
+      }).top), n && (e.position.left = i._convertPositionTo("relative", {
+        top: 0,
+        left: h - i.helperProportions.width
+      }).left), r && (e.position.left = i._convertPositionTo("relative", {
+        top: 0,
+        left: a
+      }).left)), u = s || o || n || r, "outer" !== p.snapMode && (s = Math.abs(l - g) <= f, o = Math.abs(c - v) <= f, n = Math.abs(h - d) <= f, r = Math.abs(a - m) <= f, s && (e.position.top = i._convertPositionTo("relative", {
+        top: l,
+        left: 0
+      }).top), o && (e.position.top = i._convertPositionTo("relative", {
+        top: c - i.helperProportions.height,
+        left: 0
+      }).top), n && (e.position.left = i._convertPositionTo("relative", {
+        top: 0,
+        left: h
+      }).left), r && (e.position.left = i._convertPositionTo("relative", {
+        top: 0,
+        left: a - i.helperProportions.width
+      }).left)), !i.snapElements[_].snapping && (s || o || n || r || u) && i.options.snap.snap && i.options.snap.snap.call(i.element, t, w.extend(i._uiHash(), {
+        snapItem: i.snapElements[_].item
+      })), i.snapElements[_].snapping = s || o || n || r || u);
     }
   }), w.ui.plugin.add("draggable", "stack", {
     start: function start(t, e, i) {
@@ -2608,9 +2538,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     },
     _destroy: function _destroy() {
       this._mouseDestroy();
-      for (var t = this.items.length - 1; 0 <= t; t--) {
-        this.items[t].item.removeData(this.widgetName + "-item");
-      }
+      for (var t = this.items.length - 1; 0 <= t; t--) this.items[t].item.removeData(this.widgetName + "-item");
       return this;
     },
     _mouseCapture: function _mouseCapture(t, e) {
@@ -2641,9 +2569,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         parent: this.currentItem.parent()[0]
       }, this.helper[0] !== this.currentItem[0] && this.currentItem.hide(), this._createPlaceholder(), this.scrollParent = this.placeholder.scrollParent(), w.extend(this.offset, {
         parent: this._getParentOffset()
-      }), n.containment && this._setContainment(), n.cursor && "auto" !== n.cursor && (o = this.document.find("body"), this.storedCursor = o.css("cursor"), o.css("cursor", n.cursor), this.storedStylesheet = w("<style>*{ cursor: " + n.cursor + " !important; }</style>").appendTo(o)), n.zIndex && (this.helper.css("zIndex") && (this._storedZIndex = this.helper.css("zIndex")), this.helper.css("zIndex", n.zIndex)), n.opacity && (this.helper.css("opacity") && (this._storedOpacity = this.helper.css("opacity")), this.helper.css("opacity", n.opacity)), this.scrollParent[0] !== this.document[0] && "HTML" !== this.scrollParent[0].tagName && (this.overflowOffset = this.scrollParent.offset()), this._trigger("start", t, this._uiHash()), this._preserveHelperProportions || this._cacheHelperProportions(), !i) for (s = this.containers.length - 1; 0 <= s; s--) {
-        this.containers[s]._trigger("activate", t, this._uiHash(this));
-      }
+      }), n.containment && this._setContainment(), n.cursor && "auto" !== n.cursor && (o = this.document.find("body"), this.storedCursor = o.css("cursor"), o.css("cursor", n.cursor), this.storedStylesheet = w("<style>*{ cursor: " + n.cursor + " !important; }</style>").appendTo(o)), n.zIndex && (this.helper.css("zIndex") && (this._storedZIndex = this.helper.css("zIndex")), this.helper.css("zIndex", n.zIndex)), n.opacity && (this.helper.css("opacity") && (this._storedOpacity = this.helper.css("opacity")), this.helper.css("opacity", n.opacity)), this.scrollParent[0] !== this.document[0] && "HTML" !== this.scrollParent[0].tagName && (this.overflowOffset = this.scrollParent.offset()), this._trigger("start", t, this._uiHash()), this._preserveHelperProportions || this._cacheHelperProportions(), !i) for (s = this.containers.length - 1; 0 <= s; s--) this.containers[s]._trigger("activate", t, this._uiHash(this));
       return w.ui.ddmanager && (w.ui.ddmanager.current = this), w.ui.ddmanager && !n.dropBehaviour && w.ui.ddmanager.prepareOffsets(this, t), this.dragging = !0, this._addClass(this.helper, "ui-sortable-helper"), this.helper.parent().is(this.appendTo) || (this.helper.detach().appendTo(this.appendTo), this.offset.parent = this._getParentOffset()), this.position = this.originalPosition = this._generatePosition(t), this.originalPageX = t.pageX, this.originalPageY = t.pageY, this.lastPositionAbs = this.positionAbs = this._convertPositionTo("absolute"), this._mouseDrag(t), !0;
     },
     _scroll: function _scroll(t) {
@@ -2660,12 +2586,10 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       for (this.position = this._generatePosition(t), this.positionAbs = this._convertPositionTo("absolute"), this.options.axis && "y" === this.options.axis || (this.helper[0].style.left = this.position.left + "px"), this.options.axis && "x" === this.options.axis || (this.helper[0].style.top = this.position.top + "px"), n.scroll && !1 !== this._scroll(t) && (this._refreshItemPositions(!0), w.ui.ddmanager && !n.dropBehaviour && w.ui.ddmanager.prepareOffsets(this, t)), this.dragDirection = {
         vertical: this._getDragVerticalDirection(),
         horizontal: this._getDragHorizontalDirection()
-      }, e = this.items.length - 1; 0 <= e; e--) {
-        if (s = (i = this.items[e]).item[0], (o = this._intersectsWithPointer(i)) && i.instance === this.currentContainer && !(s === this.currentItem[0] || this.placeholder[1 === o ? "next" : "prev"]()[0] === s || w.contains(this.placeholder[0], s) || "semi-dynamic" === this.options.type && w.contains(this.element[0], s))) {
-          if (this.direction = 1 === o ? "down" : "up", "pointer" !== this.options.tolerance && !this._intersectsWithSides(i)) break;
-          this._rearrange(t, i), this._trigger("change", t, this._uiHash());
-          break;
-        }
+      }, e = this.items.length - 1; 0 <= e; e--) if (s = (i = this.items[e]).item[0], (o = this._intersectsWithPointer(i)) && i.instance === this.currentContainer && !(s === this.currentItem[0] || this.placeholder[1 === o ? "next" : "prev"]()[0] === s || w.contains(this.placeholder[0], s) || "semi-dynamic" === this.options.type && w.contains(this.element[0], s))) {
+        if (this.direction = 1 === o ? "down" : "up", "pointer" !== this.options.tolerance && !this._intersectsWithSides(i)) break;
+        this._rearrange(t, i), this._trigger("change", t, this._uiHash());
+        break;
       }
       return this._contactContainers(t), w.ui.ddmanager && w.ui.ddmanager.drag(this, t), this._trigger("sort", t, this._uiHash()), this.lastPositionAbs = this.positionAbs, !1;
     },
@@ -2680,9 +2604,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         this._mouseUp(new w.Event("mouseup", {
           target: null
         })), "original" === this.options.helper ? (this.currentItem.css(this._storedCSS), this._removeClass(this.currentItem, "ui-sortable-helper")) : this.currentItem.show();
-        for (var t = this.containers.length - 1; 0 <= t; t--) {
-          this.containers[t]._trigger("deactivate", null, this._uiHash(this)), this.containers[t].containerCache.over && (this.containers[t]._trigger("out", null, this._uiHash(this)), this.containers[t].containerCache.over = 0);
-        }
+        for (var t = this.containers.length - 1; 0 <= t; t--) this.containers[t]._trigger("deactivate", null, this._uiHash(this)), this.containers[t].containerCache.over && (this.containers[t]._trigger("out", null, this._uiHash(this)), this.containers[t].containerCache.over = 0);
       }
       return this.placeholder && (this.placeholder[0].parentNode && this.placeholder[0].parentNode.removeChild(this.placeholder[0]), "original" !== this.options.helper && this.helper && this.helper[0].parentNode && this.helper.remove(), w.extend(this, {
         helper: null,
@@ -2756,28 +2678,20 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         n = [],
         r = [],
         h = this._connectWith();
-      if (h && t) for (e = h.length - 1; 0 <= e; e--) {
-        for (i = (s = w(h[e], this.document[0])).length - 1; 0 <= i; i--) {
-          (o = w.data(s[i], this.widgetFullName)) && o !== this && !o.options.disabled && r.push(["function" == typeof o.options.items ? o.options.items.call(o.element) : w(o.options.items, o.element).not(".ui-sortable-helper").not(".ui-sortable-placeholder"), o]);
-        }
-      }
+      if (h && t) for (e = h.length - 1; 0 <= e; e--) for (i = (s = w(h[e], this.document[0])).length - 1; 0 <= i; i--) (o = w.data(s[i], this.widgetFullName)) && o !== this && !o.options.disabled && r.push(["function" == typeof o.options.items ? o.options.items.call(o.element) : w(o.options.items, o.element).not(".ui-sortable-helper").not(".ui-sortable-placeholder"), o]);
       function a() {
         n.push(this);
       }
       for (r.push(["function" == typeof this.options.items ? this.options.items.call(this.element, null, {
         options: this.options,
         item: this.currentItem
-      }) : w(this.options.items, this.element).not(".ui-sortable-helper").not(".ui-sortable-placeholder"), this]), e = r.length - 1; 0 <= e; e--) {
-        r[e][0].each(a);
-      }
+      }) : w(this.options.items, this.element).not(".ui-sortable-helper").not(".ui-sortable-placeholder"), this]), e = r.length - 1; 0 <= e; e--) r[e][0].each(a);
       return w(n);
     },
     _removeCurrentsFromItems: function _removeCurrentsFromItems() {
       var i = this.currentItem.find(":data(" + this.widgetName + "-item)");
       this.items = w.grep(this.items, function (t) {
-        for (var e = 0; e < i.length; e++) {
-          if (i[e] === t.item[0]) return !1;
-        }
+        for (var e = 0; e < i.length; e++) if (i[e] === t.item[0]) return !1;
         return !0;
       });
     },
@@ -2796,36 +2710,24 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
           item: this.currentItem
         }) : w(this.options.items, this.element), this]],
         u = this._connectWith();
-      if (u && this.ready) for (e = u.length - 1; 0 <= e; e--) {
-        for (i = (s = w(u[e], this.document[0])).length - 1; 0 <= i; i--) {
-          (o = w.data(s[i], this.widgetFullName)) && o !== this && !o.options.disabled && (c.push(["function" == typeof o.options.items ? o.options.items.call(o.element[0], t, {
-            item: this.currentItem
-          }) : w(o.options.items, o.element), o]), this.containers.push(o));
-        }
-      }
-      for (e = c.length - 1; 0 <= e; e--) {
-        for (n = c[e][1], a = (r = c[e][i = 0]).length; i < a; i++) {
-          (h = w(r[i])).data(this.widgetName + "-item", n), l.push({
-            item: h,
-            instance: n,
-            width: 0,
-            height: 0,
-            left: 0,
-            top: 0
-          });
-        }
-      }
+      if (u && this.ready) for (e = u.length - 1; 0 <= e; e--) for (i = (s = w(u[e], this.document[0])).length - 1; 0 <= i; i--) (o = w.data(s[i], this.widgetFullName)) && o !== this && !o.options.disabled && (c.push(["function" == typeof o.options.items ? o.options.items.call(o.element[0], t, {
+        item: this.currentItem
+      }) : w(o.options.items, o.element), o]), this.containers.push(o));
+      for (e = c.length - 1; 0 <= e; e--) for (n = c[e][1], a = (r = c[e][i = 0]).length; i < a; i++) (h = w(r[i])).data(this.widgetName + "-item", n), l.push({
+        item: h,
+        instance: n,
+        width: 0,
+        height: 0,
+        left: 0,
+        top: 0
+      });
     },
     _refreshItemPositions: function _refreshItemPositions(t) {
-      for (var e, i, s = this.items.length - 1; 0 <= s; s--) {
-        e = this.items[s], this.currentContainer && e.instance !== this.currentContainer && e.item[0] !== this.currentItem[0] || (i = this.options.toleranceElement ? w(this.options.toleranceElement, e.item) : e.item, t || (e.width = i.outerWidth(), e.height = i.outerHeight()), i = i.offset(), e.left = i.left, e.top = i.top);
-      }
+      for (var e, i, s = this.items.length - 1; 0 <= s; s--) e = this.items[s], this.currentContainer && e.instance !== this.currentContainer && e.item[0] !== this.currentItem[0] || (i = this.options.toleranceElement ? w(this.options.toleranceElement, e.item) : e.item, t || (e.width = i.outerWidth(), e.height = i.outerHeight()), i = i.offset(), e.left = i.left, e.top = i.top);
     },
     refreshPositions: function refreshPositions(t) {
       var e, i;
-      if (this.floating = !!this.items.length && ("x" === this.options.axis || this._isFloating(this.items[0].item)), this.offsetParent && this.helper && (this.offset.parent = this._getParentOffset()), this._refreshItemPositions(t), this.options.custom && this.options.custom.refreshContainers) this.options.custom.refreshContainers.call(this);else for (e = this.containers.length - 1; 0 <= e; e--) {
-        i = this.containers[e].element.offset(), this.containers[e].containerCache.left = i.left, this.containers[e].containerCache.top = i.top, this.containers[e].containerCache.width = this.containers[e].element.outerWidth(), this.containers[e].containerCache.height = this.containers[e].element.outerHeight();
-      }
+      if (this.floating = !!this.items.length && ("x" === this.options.axis || this._isFloating(this.items[0].item)), this.offsetParent && this.helper && (this.offset.parent = this._getParentOffset()), this._refreshItemPositions(t), this.options.custom && this.options.custom.refreshContainers) this.options.custom.refreshContainers.call(this);else for (e = this.containers.length - 1; 0 <= e; e--) i = this.containers[e].element.offset(), this.containers[e].containerCache.left = i.left, this.containers[e].containerCache.top = i.top, this.containers[e].containerCache.width = this.containers[e].element.outerWidth(), this.containers[e].containerCache.height = this.containers[e].element.outerHeight();
       return this;
     },
     _createPlaceholder: function _createPlaceholder(i) {
@@ -2849,13 +2751,9 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       });
     },
     _contactContainers: function _contactContainers(t) {
-      for (var e, i, s, o, n, r, h, a, l, c = null, u = null, p = this.containers.length - 1; 0 <= p; p--) {
-        w.contains(this.currentItem[0], this.containers[p].element[0]) || (this._intersectsWith(this.containers[p].containerCache) ? c && w.contains(this.containers[p].element[0], c.element[0]) || (c = this.containers[p], u = p) : this.containers[p].containerCache.over && (this.containers[p]._trigger("out", t, this._uiHash(this)), this.containers[p].containerCache.over = 0));
-      }
+      for (var e, i, s, o, n, r, h, a, l, c = null, u = null, p = this.containers.length - 1; 0 <= p; p--) w.contains(this.currentItem[0], this.containers[p].element[0]) || (this._intersectsWith(this.containers[p].containerCache) ? c && w.contains(this.containers[p].element[0], c.element[0]) || (c = this.containers[p], u = p) : this.containers[p].containerCache.over && (this.containers[p]._trigger("out", t, this._uiHash(this)), this.containers[p].containerCache.over = 0));
       if (c) if (1 === this.containers.length) this.containers[u].containerCache.over || (this.containers[u]._trigger("over", t, this._uiHash(this)), this.containers[u].containerCache.over = 1);else {
-        for (i = 1e4, s = null, o = (a = c.floating || this._isFloating(this.currentItem)) ? "left" : "top", n = a ? "width" : "height", l = a ? "pageX" : "pageY", e = this.items.length - 1; 0 <= e; e--) {
-          w.contains(this.containers[u].element[0], this.items[e].item[0]) && this.items[e].item[0] !== this.currentItem[0] && (r = this.items[e].item.offset()[o], h = !1, t[l] - r > this.items[e][n] / 2 && (h = !0), Math.abs(t[l] - r) < i && (i = Math.abs(t[l] - r), s = this.items[e], this.direction = h ? "up" : "down"));
-        }
+        for (i = 1e4, s = null, o = (a = c.floating || this._isFloating(this.currentItem)) ? "left" : "top", n = a ? "width" : "height", l = a ? "pageX" : "pageY", e = this.items.length - 1; 0 <= e; e--) w.contains(this.containers[u].element[0], this.items[e].item[0]) && this.items[e].item[0] !== this.currentItem[0] && (r = this.items[e].item.offset()[o], h = !1, t[l] - r > this.items[e][n] / 2 && (h = !0), Math.abs(t[l] - r) < i && (i = Math.abs(t[l] - r), s = this.items[e], this.direction = h ? "up" : "down"));
         (s || this.options.dropOnEmpty) && (this.currentContainer !== this.containers[u] ? (s ? this._rearrange(t, s, null, !0) : this._rearrange(t, null, this.containers[u].element, !0), this._trigger("change", t, this._uiHash()), this.containers[u]._trigger("change", t, this._uiHash(this)), this.currentContainer = this.containers[u], this.options.placeholder.update(this.currentContainer, this.placeholder), this.scrollParent = this.placeholder.scrollParent(), this.scrollParent[0] !== this.document[0] && "HTML" !== this.scrollParent[0].tagName && (this.overflowOffset = this.scrollParent.offset()), this.containers[u]._trigger("over", t, this._uiHash(this)), this.containers[u].containerCache.over = 1) : this.currentContainer.containerCache.over || (this.containers[u]._trigger("over", t, this._uiHash()), this.currentContainer.containerCache.over = 1));
       }
     },
@@ -2949,9 +2847,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       var i,
         s = [];
       if (!this._noFinalSort && this.currentItem.parent().length && this.placeholder.before(this.currentItem), this._noFinalSort = null, this.helper[0] === this.currentItem[0]) {
-        for (i in this._storedCSS) {
-          "auto" !== this._storedCSS[i] && "static" !== this._storedCSS[i] || (this._storedCSS[i] = "");
-        }
+        for (i in this._storedCSS) "auto" !== this._storedCSS[i] && "static" !== this._storedCSS[i] || (this._storedCSS[i] = "");
         this.currentItem.css(this._storedCSS), this._removeClass(this.currentItem, "ui-sortable-helper");
       } else this.currentItem.show();
       function o(e, i, s) {
@@ -2973,13 +2869,9 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         return function (t) {
           e._trigger("update", t, this._uiHash(this));
         };
-      }.call(this, this.currentContainer)))), i = this.containers.length - 1; 0 <= i; i--) {
-        e || s.push(o("deactivate", this, this.containers[i])), this.containers[i].containerCache.over && (s.push(o("out", this, this.containers[i])), this.containers[i].containerCache.over = 0);
-      }
+      }.call(this, this.currentContainer)))), i = this.containers.length - 1; 0 <= i; i--) e || s.push(o("deactivate", this, this.containers[i])), this.containers[i].containerCache.over && (s.push(o("out", this, this.containers[i])), this.containers[i].containerCache.over = 0);
       if (this.storedCursor && (this.document.find("body").css("cursor", this.storedCursor), this.storedStylesheet.remove()), this._storedOpacity && this.helper.css("opacity", this._storedOpacity), this._storedZIndex && this.helper.css("zIndex", "auto" === this._storedZIndex ? "" : this._storedZIndex), this.dragging = !1, e || this._trigger("beforeStop", t, this._uiHash()), this.placeholder[0].parentNode.removeChild(this.placeholder[0]), this.cancelHelperRemoval || (this.helper[0] !== this.currentItem[0] && this.helper.remove(), this.helper = null), !e) {
-        for (i = 0; i < s.length; i++) {
-          s[i].call(this, t);
-        }
+        for (i = 0; i < s.length; i++) s[i].call(this, t);
         this._trigger("stop", t, this._uiHash());
       }
       return this.fromOutside = !1, !this.cancelHelperRemoval;
@@ -3026,10 +2918,10 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
         role: this.options.role,
         tabIndex: 0
       }), this._addClass("ui-menu", "ui-widget ui-widget-content"), this._on({
-        "mousedown .ui-menu-item": function mousedownUiMenuItem(t) {
+        "mousedown .ui-menu-item": function mousedown_UiMenuItem(t) {
           t.preventDefault(), this._activateItem(t);
         },
-        "click .ui-menu-item": function clickUiMenuItem(t) {
+        "click .ui-menu-item": function click_UiMenuItem(t) {
           var e = w(t.target),
             i = w(w.ui.safeActiveElement(this.document[0]));
           !this.mouseHandled && e.not(".ui-state-disabled").length && (this.select(t), t.isPropagationStopped() || (this.mouseHandled = !0), e.has(".ui-menu").length ? this.expand(t) : !this.element.is(":focus") && i.closest(".ui-menu").length && (this.element.trigger("focus", [!0]), this.active && 1 === this.active.parents(".ui-menu").length && clearTimeout(this.timer)));
@@ -3714,9 +3606,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
     }
   }
   function r(t, e) {
-    for (var n in e) {
-      t[n] = e[n];
-    }
+    for (var n in e) t[n] = e[n];
     return t;
   }
   function h(t) {
@@ -3856,15 +3746,13 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       this.addSwatch(d, n + 1, r);
     }
   }, f.updateSaturationGrid = function (t, e, n) {
-    for (var i = this.options.shades, o = this.options.hues, r = this.options.hue0, h = 0; h < i; h++) {
-      for (var a = 0; a < o; a++) {
-        var c = Math.round(360 * a / o + r) % 360,
-          u = 1 - (h + 1) / (i + 1),
-          d = this.colorModer(c, e, u),
-          p = s(d),
-          f = h + n;
-        this.addSwatch(p, a, f);
-      }
+    for (var i = this.options.shades, o = this.options.hues, r = this.options.hue0, h = 0; h < i; h++) for (var a = 0; a < o; a++) {
+      var c = Math.round(360 * a / o + r) % 360,
+        u = 1 - (h + 1) / (i + 1),
+        d = this.colorModer(c, e, u),
+        p = s(d),
+        f = h + n;
+      this.addSwatch(p, a, f);
     }
   }, f.addSwatch = function (t, e, n) {
     this.swatches[e + "," + n] = t, this.colorGrid[t.color.toUpperCase()] = {
@@ -4056,26 +3944,49 @@ $.when($.ready).then(function () {
       }); */
 
   var sortableEl = document.getElementById("sortable");
-  var sortable;
+  var sortables = [];
   if (sortableEl !== null) {
-    // eslint-disable-next-line no-undef
-    sortable = Sortable.create(sortableEl, {
-      disabled: true,
-      animation: 150,
-      forceFallback: !(navigator.userAgent.toLowerCase().indexOf("firefox") > -1),
-      draggable: ".item-container",
-      onEnd: function onEnd() {
-        var idsInOrder = sortable.toArray();
-        $.post("".concat(base, "order"), {
-          order: idsInOrder
+    var isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
+    var createSortable = function createSortable(el, options) {
+      // eslint-disable-next-line no-undef
+      var instance = Sortable.create(el, _objectSpread({
+        disabled: true,
+        animation: 150,
+        forceFallback: !isFirefox,
+        onEnd: function onEnd() {
+          $.post("".concat(base, "order"), {
+            order: instance.toArray()
+          });
+        }
+      }, options));
+      // prevent Firefox drag behavior
+      if (isFirefox) {
+        instance.option("setData", function (dataTransfer) {
+          dataTransfer.setData("Text", "");
         });
       }
-    });
-    // prevent Firefox drag behavior
-    if (navigator.userAgent.toLowerCase().indexOf("firefox") > -1) {
-      sortable.option("setData", function (dataTransfer) {
-        dataTransfer.setData("Text", "");
+      sortables.push(instance);
+      return instance;
+    };
+    if (sortableEl.classList.contains("categories")) {
+      // Categories mode: the dashboard is a list of category blocks, each
+      // holding its own items. Categories are reordered by dragging their
+      // title bar; items are reordered within their category.
+      createSortable(sortableEl, {
+        draggable: ".category",
+        handle: ".category-title"
       });
+      sortableEl.querySelectorAll(".category").forEach(function (categoryEl) {
+        createSortable(categoryEl, {
+          draggable: ".item-container"
+        });
+      });
+    } else {
+      createSortable(sortableEl, {
+        draggable: ".item-container"
+      });
+    }
+    if (isFirefox) {
       sortableEl.addEventListener("dragstart", function (event) {
         var target = event.target;
         if (target.nodeName.toLowerCase() === "a") {
@@ -4086,6 +3997,11 @@ $.when($.ready).then(function () {
       });
     }
   }
+  var setSortableDisabled = function setSortableDisabled(disabled) {
+    sortables.forEach(function (instance) {
+      return instance.option("disabled", disabled);
+    });
+  };
   $("#main").on("mouseenter", "#sortable .item", function () {
     $(this).siblings(".tooltip").addClass("active");
     $(".refresh", this).addClass("active");
@@ -4233,10 +4149,10 @@ $.when($.ready).then(function () {
       $(".item-edit").hide();
       $("#app").removeClass("sidebar");
       $("#sortable .tooltip").css("display", "");
-      if (sortable !== undefined) sortable.option("disabled", true);
+      setSortableDisabled(true);
     } else {
       $("#sortable .tooltip").css("display", "none");
-      if (sortable !== undefined) sortable.option("disabled", false);
+      setSortableDisabled(false);
       setTimeout(function () {
         $(".add-item").fadeIn();
         $(".item-edit").fadeIn();
@@ -4489,6 +4405,10 @@ var fetchAppDetails = function fetchAppDetails(appId) {
       app: appId
     })
   }).then(function (response) {
+    // A missing app now returns a genuine 404 (see ItemController::appload).
+    // fetch() does not reject on 4xx, so surface it as a rejection here to
+    // keep importItems reporting "Failed to find app id" rather than treating
+    // the {"error":...} body as a successful import.
     if (!response.ok) {
       return Promise.reject(new Error("Failed to find app id: ".concat(appId)));
     }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,8 +1,3 @@
-function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
-function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _defineProperty(e, r, t) { return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, { value: t, enumerable: !0, configurable: !0, writable: !0 }) : e[r] = t, e; }
-function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
-function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 /*! Sortable 1.15.6 - MIT | git://github.com/SortableJS/Sortable.git */
 !function (t, e) {
@@ -3947,18 +3942,21 @@ $.when($.ready).then(function () {
   var sortables = [];
   if (sortableEl !== null) {
     var isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
-    var createSortable = function createSortable(el, options) {
+    var createSortable = function createSortable(el, draggable, handle) {
       // eslint-disable-next-line no-undef
-      var instance = Sortable.create(el, _objectSpread({
+      var instance = Sortable.create(el, {
         disabled: true,
         animation: 150,
         forceFallback: !isFirefox,
-        onEnd: function onEnd() {
+        draggable: draggable,
+        handle: handle,
+        onEnd: function onEnd(evt) {
+          // eslint-disable-next-line no-undef
           $.post("".concat(base, "order"), {
-            order: instance.toArray()
+            order: Sortable.get(evt.to).toArray()
           });
         }
-      }, options));
+      });
       // prevent Firefox drag behavior
       if (isFirefox) {
         instance.option("setData", function (dataTransfer) {
@@ -3966,26 +3964,20 @@ $.when($.ready).then(function () {
         });
       }
       sortables.push(instance);
-      return instance;
     };
-    if (sortableEl.classList.contains("categories")) {
-      // Categories mode: the dashboard is a list of category blocks, each
-      // holding its own items. Categories are reordered by dragging their
-      // title bar; items are reordered within their category.
-      createSortable(sortableEl, {
-        draggable: ".category",
-        handle: ".category-title"
-      });
-      sortableEl.querySelectorAll(".category").forEach(function (categoryEl) {
-        createSortable(categoryEl, {
-          draggable: ".item-container"
-        });
-      });
-    } else {
-      createSortable(sortableEl, {
-        draggable: ".item-container"
-      });
+
+    // In categories mode the items are nested inside .category blocks, so
+    // the categories get their own sortable (dragged by their title bar) and
+    // each category sorts its own items. The item sortables deliberately
+    // share no `group`: moving an item between categories is a tag change
+    // that /order cannot express.
+    var categoryEls = Array.from(sortableEl.querySelectorAll(".category"));
+    if (categoryEls.length > 0) {
+      createSortable(sortableEl, ".category", ".category > .title");
     }
+    (categoryEls.length > 0 ? categoryEls : [sortableEl]).forEach(function (el) {
+      createSortable(el, ".item-container");
+    });
     if (isFirefox) {
       sortableEl.addEventListener("dragstart", function (event) {
         var target = event.target;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,3 +1,8 @@
+function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function _defineProperty(e, r, t) { return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, { value: t, enumerable: !0, configurable: !0, writable: !0 }) : e[r] = t, e; }
+function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
+function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 /*! Sortable 1.15.6 - MIT | git://github.com/SortableJS/Sortable.git */
 !function (t, e) {
@@ -3944,19 +3949,21 @@ $.when($.ready).then(function () {
     var isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
     var createSortable = function createSortable(el, draggable, handle) {
       // eslint-disable-next-line no-undef
-      var instance = Sortable.create(el, {
+      var instance = Sortable.create(el, _objectSpread(_objectSpread({
         disabled: true,
         animation: 150,
         forceFallback: !isFirefox,
-        draggable: draggable,
-        handle: handle,
+        draggable: draggable
+      }, handle ? {
+        handle: handle
+      } : {}), {}, {
         onEnd: function onEnd(evt) {
           // eslint-disable-next-line no-undef
           $.post("".concat(base, "order"), {
             order: Sortable.get(evt.to).toArray()
           });
         }
-      });
+      }));
       // prevent Firefox drag behavior
       if (isFirefox) {
         instance.option("setData", function (dataTransfer) {
@@ -3967,10 +3974,11 @@ $.when($.ready).then(function () {
     };
 
     // In categories mode the items are nested inside .category blocks, so
-    // the categories get their own sortable (dragged by their title bar) and
-    // each category sorts its own items. The item sortables deliberately
-    // share no `group`: moving an item between categories is a tag change
-    // that /order cannot express.
+    // the categories get their own sortable (dragged by their title bar,
+    // whose link is draggable="false" so the native drag source is the
+    // block rather than the anchor) and each category sorts its own items.
+    // The item sortables deliberately share no `group`: moving an item
+    // between categories is a tag change that /order cannot express.
     var categoryEls = Array.from(sortableEl.querySelectorAll(".category"));
     if (categoryEls.length > 0) {
       createSortable(sortableEl, ".category", ".category > .title");

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/css/app.css": "/css/app.css?id=271cb5f5a1f91d0a6dfbc65e374ffc14",
-    "/js/app.js": "/js/app.js?id=410702534e5132611361eea61a110b2e"
+    "/js/app.js": "/js/app.js?id=5012c582b645a2fc9fd8f2bb3dbc3e09"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/css/app.css": "/css/app.css?id=271cb5f5a1f91d0a6dfbc65e374ffc14",
-    "/js/app.js": "/js/app.js?id=2ebeb753597d1cbbf88d8bc652e4af5b"
+    "/js/app.js": "/js/app.js?id=410702534e5132611361eea61a110b2e"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/css/app.css": "/css/app.css?id=271cb5f5a1f91d0a6dfbc65e374ffc14",
-    "/js/app.js": "/js/app.js?id=5012c582b645a2fc9fd8f2bb3dbc3e09"
+    "/js/app.js": "/js/app.js?id=3691c568d756f5a2c992545306fc22dd"
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -63,7 +63,7 @@ $.when($.ready).then(() => {
         animation: 150,
         forceFallback: !isFirefox,
         draggable,
-        handle,
+        ...(handle ? { handle } : {}),
         onEnd(evt) {
           // eslint-disable-next-line no-undef
           $.post(`${base}order`, { order: Sortable.get(evt.to).toArray() });
@@ -79,10 +79,11 @@ $.when($.ready).then(() => {
     };
 
     // In categories mode the items are nested inside .category blocks, so
-    // the categories get their own sortable (dragged by their title bar) and
-    // each category sorts its own items. The item sortables deliberately
-    // share no `group`: moving an item between categories is a tag change
-    // that /order cannot express.
+    // the categories get their own sortable (dragged by their title bar,
+    // whose link is draggable="false" so the native drag source is the
+    // block rather than the anchor) and each category sorts its own items.
+    // The item sortables deliberately share no `group`: moving an item
+    // between categories is a tag change that /order cannot express.
     const categoryEls = Array.from(sortableEl.querySelectorAll(".category"));
     if (categoryEls.length > 0) {
       createSortable(sortableEl, ".category", ".category > .title");

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -56,16 +56,18 @@ $.when($.ready).then(() => {
   const sortables = [];
   if (sortableEl !== null) {
     const isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
-    const createSortable = (el, options) => {
+    const createSortable = (el, draggable, handle) => {
       // eslint-disable-next-line no-undef
       const instance = Sortable.create(el, {
         disabled: true,
         animation: 150,
         forceFallback: !isFirefox,
-        onEnd() {
-          $.post(`${base}order`, { order: instance.toArray() });
+        draggable,
+        handle,
+        onEnd(evt) {
+          // eslint-disable-next-line no-undef
+          $.post(`${base}order`, { order: Sortable.get(evt.to).toArray() });
         },
-        ...options,
       });
       // prevent Firefox drag behavior
       if (isFirefox) {
@@ -74,23 +76,20 @@ $.when($.ready).then(() => {
         });
       }
       sortables.push(instance);
-      return instance;
     };
 
-    if (sortableEl.classList.contains("categories")) {
-      // Categories mode: the dashboard is a list of category blocks, each
-      // holding its own items. Categories are reordered by dragging their
-      // title bar; items are reordered within their category.
-      createSortable(sortableEl, {
-        draggable: ".category",
-        handle: ".category-title",
-      });
-      sortableEl.querySelectorAll(".category").forEach((categoryEl) => {
-        createSortable(categoryEl, { draggable: ".item-container" });
-      });
-    } else {
-      createSortable(sortableEl, { draggable: ".item-container" });
+    // In categories mode the items are nested inside .category blocks, so
+    // the categories get their own sortable (dragged by their title bar) and
+    // each category sorts its own items. The item sortables deliberately
+    // share no `group`: moving an item between categories is a tag change
+    // that /order cannot express.
+    const categoryEls = Array.from(sortableEl.querySelectorAll(".category"));
+    if (categoryEls.length > 0) {
+      createSortable(sortableEl, ".category", ".category > .title");
     }
+    (categoryEls.length > 0 ? categoryEls : [sortableEl]).forEach((el) => {
+      createSortable(el, ".item-container");
+    });
 
     if (isFirefox) {
       sortableEl.addEventListener("dragstart", (event) => {

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -53,27 +53,46 @@ $.when($.ready).then(() => {
       }); */
 
   const sortableEl = document.getElementById("sortable");
-  let sortable;
+  const sortables = [];
   if (sortableEl !== null) {
-    // eslint-disable-next-line no-undef
-    sortable = Sortable.create(sortableEl, {
-      disabled: true,
-      animation: 150,
-      forceFallback: !(
-        navigator.userAgent.toLowerCase().indexOf("firefox") > -1
-      ),
-      draggable: ".item-container",
-      onEnd() {
-        const idsInOrder = sortable.toArray();
-        $.post(`${base}order`, { order: idsInOrder });
-      },
-    });
-    // prevent Firefox drag behavior
-    if (navigator.userAgent.toLowerCase().indexOf("firefox") > -1) {
-      sortable.option("setData", (dataTransfer) => {
-        dataTransfer.setData("Text", "");
+    const isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
+    const createSortable = (el, options) => {
+      // eslint-disable-next-line no-undef
+      const instance = Sortable.create(el, {
+        disabled: true,
+        animation: 150,
+        forceFallback: !isFirefox,
+        onEnd() {
+          $.post(`${base}order`, { order: instance.toArray() });
+        },
+        ...options,
       });
+      // prevent Firefox drag behavior
+      if (isFirefox) {
+        instance.option("setData", (dataTransfer) => {
+          dataTransfer.setData("Text", "");
+        });
+      }
+      sortables.push(instance);
+      return instance;
+    };
 
+    if (sortableEl.classList.contains("categories")) {
+      // Categories mode: the dashboard is a list of category blocks, each
+      // holding its own items. Categories are reordered by dragging their
+      // title bar; items are reordered within their category.
+      createSortable(sortableEl, {
+        draggable: ".category",
+        handle: ".category-title",
+      });
+      sortableEl.querySelectorAll(".category").forEach((categoryEl) => {
+        createSortable(categoryEl, { draggable: ".item-container" });
+      });
+    } else {
+      createSortable(sortableEl, { draggable: ".item-container" });
+    }
+
+    if (isFirefox) {
       sortableEl.addEventListener("dragstart", (event) => {
         const { target } = event;
         if (target.nodeName.toLowerCase() === "a") {
@@ -84,6 +103,9 @@ $.when($.ready).then(() => {
       });
     }
   }
+  const setSortableDisabled = (disabled) => {
+    sortables.forEach((instance) => instance.option("disabled", disabled));
+  };
 
   $("#main")
     .on("mouseenter", "#sortable .item", function () {
@@ -263,10 +285,10 @@ $.when($.ready).then(() => {
         $(".item-edit").hide();
         $("#app").removeClass("sidebar");
         $("#sortable .tooltip").css("display", "");
-        if (sortable !== undefined) sortable.option("disabled", true);
+        setSortableDisabled(true);
       } else {
         $("#sortable .tooltip").css("display", "none");
-        if (sortable !== undefined) sortable.option("disabled", false);
+        setSortableDisabled(false);
         setTimeout(() => {
           $(".add-item").fadeIn();
           $(".item-edit").fadeIn();

--- a/resources/views/sortable.blade.php
+++ b/resources/views/sortable.blade.php
@@ -4,7 +4,7 @@
             @foreach($categories as $category)
                 <?php $apps = $category->children; ?>
                 <div class="category item-containerz" data-name="{{ $category->title }}" data-id="{{ $category->id }}">
-                <div class="title"><a href="{{ $category->link }}" style="{{ $category->colour ? 'color: ' . $category->colour .';' : '' }}">{{ $category->title }}</a></div>
+                <div class="title"><a draggable="false" href="{{ $category->link }}" style="{{ $category->colour ? 'color: ' . $category->colour .';' : '' }}">{{ $category->title }}</a></div>
                 @foreach($apps as $app)
                     @include('item')
                 @endforeach

--- a/resources/views/sortable.blade.php
+++ b/resources/views/sortable.blade.php
@@ -4,7 +4,7 @@
             @foreach($categories as $category)
                 <?php $apps = $category->children; ?>
                 <div class="category item-containerz" data-name="{{ $category->title }}" data-id="{{ $category->id }}">
-                <div class="title"><a href="{{ $category->link }}" style="{{ $category->colour ? 'color: ' . $category->colour .';' : '' }}">{{ $category->title }}</a></div>
+                <div class="title category-title"><a href="{{ $category->link }}" style="{{ $category->colour ? 'color: ' . $category->colour .';' : '' }}">{{ $category->title }}</a></div>
                 @foreach($apps as $app)
                     @include('item')
                 @endforeach

--- a/resources/views/sortable.blade.php
+++ b/resources/views/sortable.blade.php
@@ -4,7 +4,7 @@
             @foreach($categories as $category)
                 <?php $apps = $category->children; ?>
                 <div class="category item-containerz" data-name="{{ $category->title }}" data-id="{{ $category->id }}">
-                <div class="title category-title"><a href="{{ $category->link }}" style="{{ $category->colour ? 'color: ' . $category->colour .';' : '' }}">{{ $category->title }}</a></div>
+                <div class="title"><a href="{{ $category->link }}" style="{{ $category->colour ? 'color: ' . $category->colour .';' : '' }}">{{ $category->title }}</a></div>
                 @foreach($apps as $app)
                     @include('item')
                 @endforeach

--- a/tests/Feature/AjaxPostEndpointsTest.php
+++ b/tests/Feature/AjaxPostEndpointsTest.php
@@ -38,6 +38,45 @@ class AjaxPostEndpointsTest extends TestCase
         $this->assertSame(1, (int) $first->fresh()->order);
     }
 
+    public function test_order_endpoint_reorders_categories_including_the_home_tag(): void
+    {
+        $this->seed();
+
+        // The seeder creates the home dashboard tag at id 0; it is a valid
+        // category and must not be dropped as a "falsy" id.
+        $media = Item::factory()->create(['title' => 'Media', 'type' => 1, 'order' => 0]);
+        $work = Item::factory()->create(['title' => 'Work', 'type' => 1, 'order' => 1]);
+
+        $response = $this->post('/order', [
+            'order' => [$work->id, '0', $media->id],
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertSame(0, (int) $work->fresh()->order);
+        $this->assertSame(1, (int) Item::find(0)->order);
+        $this->assertSame(2, (int) $media->fresh()->order);
+    }
+
+    public function test_order_endpoint_skips_ids_that_no_longer_exist(): void
+    {
+        $this->seed();
+
+        $first = Item::factory()->create(['order' => 5]);
+        $second = Item::factory()->create(['order' => 9]);
+
+        $response = $this->post('/order', [
+            'order' => [$second->id, 999999, $first->id],
+        ]);
+
+        $response->assertStatus(200);
+
+        // Positions are taken from the posted list, so the missing id leaves
+        // a gap rather than shifting the items after it.
+        $this->assertSame(0, (int) $second->fresh()->order);
+        $this->assertSame(2, (int) $first->fresh()->order);
+    }
+
     public function test_appload_returns_null_for_the_none_selection(): void
     {
         $this->seed();

--- a/tests/Feature/DashTest.php
+++ b/tests/Feature/DashTest.php
@@ -16,7 +16,7 @@ class DashTest extends TestCase
      * Helpers
      */
 
-    private function addPinnedItemWithTitleToDB($title)
+    private function addPinnedItemWithTitleToDB($title, $tagId = 0): Item
     {
         $item = Item::factory()
             ->create([
@@ -26,22 +26,20 @@ class DashTest extends TestCase
 
         ItemTag::factory()->create([
             'item_id' => $item->id,
-            'tag_id' => 0,
+            'tag_id' => $tagId,
         ]);
+
+        return $item;
     }
 
-    private function addTagWithTitleToDB($title)
+    private function addTagWithTitleToDB($title, array $attributes = []): Item
     {
-        Item::factory()
-            ->create([
+        return Item::factory()
+            ->create($attributes + [
                 'title' => $title,
                 'type' => 1,
             ]);
     }
-
-    /**
-     * Test Cases
-     */
 
     public function test_loads_empty_dash(): void
     {
@@ -89,13 +87,7 @@ class DashTest extends TestCase
         Setting::where('key', 'treat_tags_as')->update(['value' => 'tags']);
         Setting::where('key', 'default_tag')->update(['value' => 'home-dashboard']);
 
-        Item::factory()->create([
-            'title' => 'Home',
-            'url' => 'home-dashboard',
-            'type' => 1,
-            'pinned' => 1,
-            'user_id' => 0,
-        ]);
+        $this->addTagWithTitleToDB('Home', ['url' => 'home-dashboard', 'pinned' => 1, 'user_id' => 0]);
 
         $response = $this->get('/');
 
@@ -109,30 +101,15 @@ class DashTest extends TestCase
 
         Setting::where('key', 'treat_tags_as')->update(['value' => 'categories']);
 
-        $tag = Item::factory()->create([
-            'title' => 'Media',
-            'url' => 'media',
-            'type' => 1,
-            'pinned' => 1,
-            'user_id' => 0,
-        ]);
-        $app = Item::factory()->create([
-            'title' => 'Plex',
-            'pinned' => 1,
-        ]);
-        ItemTag::factory()->create([
-            'item_id' => $app->id,
-            'tag_id' => $tag->id,
-        ]);
+        $tag = $this->addTagWithTitleToDB('Media', ['url' => 'media', 'pinned' => 1, 'user_id' => 0]);
+        $app = $this->addPinnedItemWithTitleToDB('Plex', $tag->id);
 
         $response = $this->get('/');
 
         $response->assertStatus(200);
-        $response->assertSee('<div id="sortable" class="categories">', false);
-        // The category block carries its id (what Sortable posts to /order)
-        // and a title bar that acts as the drag handle for reordering categories.
+        // The category block and the item inside it both carry the id that
+        // Sortable posts to /order.
         $response->assertSee('class="category item-containerz" data-name="Media" data-id="' . $tag->id . '"', false);
-        $response->assertSee('class="title category-title"', false);
         $response->assertSee('data-name="Plex" data-id="' . $app->id . '"', false);
     }
 }

--- a/tests/Feature/DashTest.php
+++ b/tests/Feature/DashTest.php
@@ -111,5 +111,13 @@ class DashTest extends TestCase
         // Sortable posts to /order.
         $response->assertSee('class="category item-containerz" data-name="Media" data-id="' . $tag->id . '"', false);
         $response->assertSee('data-name="Plex" data-id="' . $app->id . '"', false);
+        // The item is rendered inside its category block (what the nested
+        // per-category sortable relies on), and the title link opts out of
+        // native dragging so the category itself is the drag source.
+        $html = $response->getContent();
+        $categoryPos = strpos($html, 'data-id="' . $tag->id . '"');
+        $itemPos = strpos($html, 'data-id="' . $app->id . '"');
+        $this->assertLessThan($itemPos, $categoryPos);
+        $this->assertStringContainsString('<a draggable="false" href=', $html);
     }
 }

--- a/tests/Feature/DashTest.php
+++ b/tests/Feature/DashTest.php
@@ -102,4 +102,37 @@ class DashTest extends TestCase
         $response->assertStatus(200);
         $response->assertSee('data-default-tag="home-dashboard"', false);
     }
+
+    public function test_categories_mode_renders_sortable_category_and_item_markup(): void
+    {
+        $this->seed();
+
+        Setting::where('key', 'treat_tags_as')->update(['value' => 'categories']);
+
+        $tag = Item::factory()->create([
+            'title' => 'Media',
+            'url' => 'media',
+            'type' => 1,
+            'pinned' => 1,
+            'user_id' => 0,
+        ]);
+        $app = Item::factory()->create([
+            'title' => 'Plex',
+            'pinned' => 1,
+        ]);
+        ItemTag::factory()->create([
+            'item_id' => $app->id,
+            'tag_id' => $tag->id,
+        ]);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee('<div id="sortable" class="categories">', false);
+        // The category block carries its id (what Sortable posts to /order)
+        // and a title bar that acts as the drag handle for reordering categories.
+        $response->assertSee('class="category item-containerz" data-name="Media" data-id="' . $tag->id . '"', false);
+        $response->assertSee('class="title category-title"', false);
+        $response->assertSee('data-name="Plex" data-id="' . $app->id . '"', false);
+    }
 }


### PR DESCRIPTION
Fixes #1591

## What

With "treat tags as" set to categories, the dashboard renders `.category` blocks with the items nested inside them. The single Sortable instance on `#sortable` was configured with `draggable: .item-container`, which only matches direct children, so in categories mode nothing was draggable at all and the reorder button appeared to do nothing.

## Fix

- Create one Sortable for the categories (dragged via their title bar, which gets a `category-title` class to act as the handle) plus one per category for the items inside it.
- Each instance posts its own `toArray()` to `/order`; `setOrder` already treats tags and apps the same way (both are `Item` rows with an `order` column), so no backend change is needed.
- The config-mode toggle now enables/disables every instance instead of a single one.
- Folders/tags modes are unchanged (still one instance on `#sortable`).

## Tests

- New `DashTest::test_categories_mode_renders_sortable_category_and_item_markup` guards the markup the JS depends on (container class, category `data-id`, the drag-handle class, item `data-id`).
- Full suite green locally, `eslint` clean.

## Note on the bundle

`public/js/app.js` was rebuilt with `npx mix`. The diff is larger than the source change because the committed bundle was built against sortablejs 1.15.2 while `package-lock.json` pins 1.15.6; this brings it in line with the lockfile. CSS output was left untouched.