### PR TITLE
Offer the Home dashboard as a default tag option

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -50,9 +50,7 @@ class ItemController extends Controller
             } elseif ($treat_tags_as == 'tags') {
                 $data['apps'] = Item::with('parents')->where('type', 0)->pinned()->orderBy('order', 'asc')->get();
                 $data['all_apps'] = Item::where('type', 0)->orderBy('order', 'asc')->get();
-                $data['taglist'] = Item::where('id', 0)->orWhere(function ($query) {
-                    $query->where('type', 1)->pinned();
-                })->orderBy('order', 'asc')->get();
+                $data['taglist'] = Item::taglist()->orderBy('order', 'asc')->get();
             } else {
                 $data['apps'] = Item::whereHas('parents', function ($query) {
                     $query->where('id', 0);
@@ -70,9 +68,7 @@ class ItemController extends Controller
             } elseif ($treat_tags_as == 'tags') {
                 $data['apps'] = Item::with('parents')->where('type', 0)->pinned()->orderBy('order', 'asc')->get();
                 $data['all_apps'] = Item::where('type', 0)->orderBy('order', 'asc')->get();
-                $data['taglist'] = Item::where('id', 0)->orWhere(function ($query) {
-                    $query->where('type', 1)->pinned();
-                })->orderBy('order', 'asc')->get();
+                $data['taglist'] = Item::taglist()->orderBy('order', 'asc')->get();
             } else {
                 $data['apps'] = Item::whereHas('parents', function ($query) {
                     $query->where('id', 0);

--- a/app/Item.php
+++ b/app/Item.php
@@ -122,6 +122,17 @@ class Item extends Model
         return $query->where('pinned', 1);
     }
 
+    /**
+     * Scope a query to the tags shown in the dashboard taglist: the home
+     * dashboard (root tag, id 0) plus every pinned tag.
+     */
+    public function scopeTaglist(Builder $query): Builder
+    {
+        return $query->where('id', 0)->orWhere(function (Builder $query) {
+            $query->where('type', 1)->pinned();
+        });
+    }
+
     public static function checkConfig($config)
     {
         // die(print_r($config));

--- a/app/Setting.php
+++ b/app/Setting.php
@@ -124,11 +124,7 @@ class Setting extends Model
                     if ($this->key === 'search_provider') {
                         $options = Search::providers()->pluck('name', 'id')->toArray();
                     } elseif ($this->key === 'default_tag') {
-                        $options = [];
-                        $tags = Item::where('type', 1)->where('id', '>', 0)->pinned()->orderBy('title', 'asc')->get();
-                        foreach ($tags as $tag) {
-                            $options[$tag->tag_url] = $tag->title;
-                        }
+                        $options = self::defaultTagOptions();
                     }
                     $value = (array_key_exists($this->value, $options))
                         ? __($options[$this->value])
@@ -197,11 +193,7 @@ class Setting extends Model
                 if ($this->key === 'search_provider') {
                     $options = Search::providers()->pluck('name', 'id');
                 } elseif ($this->key === 'default_tag') {
-                    $options = ['' => 'app.options.none'];
-                    $tags = Item::where('type', 1)->where('id', '>', 0)->pinned()->orderBy('title', 'asc')->get();
-                    foreach ($tags as $tag) {
-                        $options[$tag->tag_url] = $tag->title;
-                    }
+                    $options = ['' => 'app.options.none'] + self::defaultTagOptions();
                 }
                 $value = '<select name="value" class="form-control">';
                 foreach ($options as $key => $opt) {
@@ -310,5 +302,30 @@ class Setting extends Model
     public static function user()
     {
         return User::currentUser();
+    }
+
+    /**
+     * Tags that can be picked as the default tag, keyed by the slug the
+     * dashboard taglist uses (the value stored in the setting).
+     *
+     * Mirrors the taglist rendered in "tags" mode: the Home dashboard (root
+     * tag, id 0) first, then every pinned tag alphabetically.
+     *
+     * @return array<string, string>
+     */
+    public static function defaultTagOptions(): array
+    {
+        $options = [];
+
+        if ($home = Item::find(0)) {
+            $options[$home->tag_url] = $home->title;
+        }
+
+        $tags = Item::where('type', 1)->where('id', '>', 0)->pinned()->orderBy('title', 'asc')->get();
+        foreach ($tags as $tag) {
+            $options[$tag->tag_url] = $tag->title;
+        }
+
+        return $options;
     }
 }

--- a/app/Setting.php
+++ b/app/Setting.php
@@ -305,27 +305,17 @@ class Setting extends Model
     }
 
     /**
-     * Tags that can be picked as the default tag, keyed by the slug the
-     * dashboard taglist uses (the value stored in the setting).
-     *
-     * Mirrors the taglist rendered in "tags" mode: the Home dashboard (root
-     * tag, id 0) first, then every pinned tag alphabetically.
+     * Tags offered by the default_tag setting, keyed by their taglist slug:
+     * the home dashboard first, then the pinned tags by title.
      *
      * @return array<string, string>
      */
     public static function defaultTagOptions(): array
     {
-        $options = [];
-
-        if ($home = Item::find(0)) {
-            $options[$home->tag_url] = $home->title;
-        }
-
-        $tags = Item::where('type', 1)->where('id', '>', 0)->pinned()->orderBy('title', 'asc')->get();
-        foreach ($tags as $tag) {
-            $options[$tag->tag_url] = $tag->title;
-        }
-
-        return $options;
+        return Item::taglist()
+            ->get()
+            ->sortBy(fn (Item $tag) => $tag->id === 0 ? '' : $tag->title)
+            ->pluck('title', 'tag_url')
+            ->toArray();
     }
 }

--- a/tests/Feature/DashTest.php
+++ b/tests/Feature/DashTest.php
@@ -103,7 +103,7 @@ class DashTest extends TestCase
         $response->assertSee('data-default-tag="home-dashboard"', false);
     }
 
-    public function test_tags_mode_renders_the_home_dashboard_chip_matching_the_default_tag_slug(): void
+    public function test_dash_can_default_to_the_home_dashboard_tag(): void
     {
         $this->seed();
 
@@ -115,6 +115,7 @@ class DashTest extends TestCase
         $response = $this->get('/');
 
         $response->assertStatus(200);
+        // The stored slug matches the chip and the tile class the JS filters on.
         $response->assertSee('data-default-tag="0-dash"', false);
         $response->assertSee('data-tag="tag-0-dash"', false);
         $response->assertSee('class="item-container tag-0-dash"', false);

--- a/tests/Feature/DashTest.php
+++ b/tests/Feature/DashTest.php
@@ -102,4 +102,21 @@ class DashTest extends TestCase
         $response->assertStatus(200);
         $response->assertSee('data-default-tag="home-dashboard"', false);
     }
+
+    public function test_tags_mode_renders_the_home_dashboard_chip_matching_the_default_tag_slug(): void
+    {
+        $this->seed();
+
+        Setting::where('key', 'treat_tags_as')->update(['value' => 'tags']);
+        Setting::where('key', 'default_tag')->update(['value' => '0-dash']);
+
+        $this->addPinnedItemWithTitleToDB('Home Item');
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee('data-default-tag="0-dash"', false);
+        $response->assertSee('data-tag="tag-0-dash"', false);
+        $response->assertSee('class="item-container tag-0-dash"', false);
+    }
 }

--- a/tests/Unit/database/seeders/SettingsSeederTest.php
+++ b/tests/Unit/database/seeders/SettingsSeederTest.php
@@ -78,32 +78,14 @@ class SettingsSeederTest extends TestCase
 
         // The unpinned tag is excluded.
         $this->assertStringNotContainsString('value="archive"', $editValue);
-    }
 
-    public function test_default_tag_edit_value_offers_the_home_dashboard_first(): void
-    {
-        $this->seed();
-
-        Item::factory()->create([
-            'title' => 'Media',
-            'url' => 'media',
-            'type' => 1,
-            'pinned' => 1,
-            'user_id' => 0,
-        ]);
-
-        $setting = Setting::where('key', 'default_tag')->first();
-        $editValue = $setting->edit_value;
-
-        // The root tag (id 0) is what the dashboard taglist renders as the
-        // "Home Dashboard" chip, under the "0-dash" slug; its title is a
-        // translation key and must be rendered translated.
+        // The root tag (id 0) is what the taglist renders as the "Home
+        // Dashboard" chip, under the "0-dash" slug; its title is a
+        // translation key and is rendered translated, right after "none".
         $this->assertStringContainsString('value="0-dash"', $editValue);
         $this->assertStringContainsString('>' . __('app.dashboard') . '</option>', $editValue);
-
-        // It is listed right after "none", ahead of the user's own tags.
         $this->assertLessThan(
-            strpos($editValue, 'value="media"'),
+            strpos($editValue, 'value="home-dashboard"'),
             strpos($editValue, 'value="0-dash"')
         );
     }

--- a/tests/Unit/database/seeders/SettingsSeederTest.php
+++ b/tests/Unit/database/seeders/SettingsSeederTest.php
@@ -112,8 +112,9 @@ class SettingsSeederTest extends TestCase
     {
         $this->seed();
 
+        // list_value re-reads the stored value, so it has to be persisted.
+        Setting::where('key', 'default_tag')->update(['value' => '0-dash']);
         $setting = Setting::where('key', 'default_tag')->first();
-        $setting->value = '0-dash';
 
         $this->assertSame(__('app.dashboard'), $setting->list_value);
     }

--- a/tests/Unit/database/seeders/SettingsSeederTest.php
+++ b/tests/Unit/database/seeders/SettingsSeederTest.php
@@ -79,4 +79,42 @@ class SettingsSeederTest extends TestCase
         // The unpinned tag is excluded.
         $this->assertStringNotContainsString('value="archive"', $editValue);
     }
+
+    public function test_default_tag_edit_value_offers_the_home_dashboard_first(): void
+    {
+        $this->seed();
+
+        Item::factory()->create([
+            'title' => 'Media',
+            'url' => 'media',
+            'type' => 1,
+            'pinned' => 1,
+            'user_id' => 0,
+        ]);
+
+        $setting = Setting::where('key', 'default_tag')->first();
+        $editValue = $setting->edit_value;
+
+        // The root tag (id 0) is what the dashboard taglist renders as the
+        // "Home Dashboard" chip, under the "0-dash" slug; its title is a
+        // translation key and must be rendered translated.
+        $this->assertStringContainsString('value="0-dash"', $editValue);
+        $this->assertStringContainsString('>' . __('app.dashboard') . '</option>', $editValue);
+
+        // It is listed right after "none", ahead of the user's own tags.
+        $this->assertLessThan(
+            strpos($editValue, 'value="media"'),
+            strpos($editValue, 'value="0-dash"')
+        );
+    }
+
+    public function test_default_tag_list_value_shows_the_home_dashboard_when_selected(): void
+    {
+        $this->seed();
+
+        $setting = Setting::where('key', 'default_tag')->first();
+        $setting->value = '0-dash';
+
+        $this->assertSame(__('app.dashboard'), $setting->list_value);
+    }
 }


### PR DESCRIPTION
Fixes #1589

## What

With "treat tags as" = tags, the taglist already renders the root tag (id 0) as a **Home Dashboard** chip under the `0-dash` slug, and tiles tagged only to the root carry the `tag-0-dash` class, so the existing auto-select-on-load logic handles it fine. The **Default tag** setting simply never offered it: both the edit dropdown and the settings-list display filtered tags with `id > 0`.

## Fix

- New `Setting::defaultTagOptions()` builds the slug => title list used by both the edit dropdown and the list display (previously duplicated). The root tag comes first, then the pinned tags alphabetically as before.
- The root tag's title is the `app.dashboard` translation key, which both paths already run through `__()`, so it renders as "Home Dashboard" in the user's language.

## Tests

- `SettingsSeederTest`: the dropdown offers `0-dash` with the translated label, listed right after "none"; the list display shows the translated title when selected.
- `DashTest`: tags mode exposes `data-default-tag="0-dash"` alongside the matching chip and tile class.
- Full suite green locally.