### PR TITLE
Update to latest Docker spec

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,15 +1,15 @@
-version: "3"
 services:
   nginx:
     build:
       context: .
       dockerfile: nginx/Dockerfile
-    ports: 
+    ports:
       - "8080:80"
     networks:
       - internal
     volumes:
       - ../:/var/www/html
+
   php:
     build:
       context: .
@@ -21,6 +21,7 @@ services:
       XDEBUG_CONFIG: client_host=host.docker.internal client_port=9003
     volumes:
       - ../:/var/www/html
+
 networks:
   internal:
     driver: bridge


### PR DESCRIPTION
| Aspect | Status |
|--------|--------|
| **Filename** | `compose.yaml` (new) or `docker-compose.yml` (legacy) |
| **`version:`** | ❌ **No longer required** — ignored by Docker Compose |
| **Current Spec** | Docker Compose v2+ (since 2021) |