### PR TITLE
Bump version to 2.8.3

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Facade;
 
 return [
 
-    'version' => '2.8.2',
+    'version' => '2.8.3',
 
     'appsource' => env('APP_SOURCE', 'https://appslist.heimdall.site/'),
 


### PR DESCRIPTION
Automated version bump. Merging this PR will tag v2.8.3 and publish the GitHub release. Merge it last, once everything for the release is on 2.x.